### PR TITLE
[PR TOAZ-82] Request inspectors 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ c.ServerApp.websocket_url = 'wss://qi-relay.servicebus.windows.net/$hc/qi-2-16'
 
 The listener enables the inspection of the relayed HTTP requests.
 HTTP requests could be accepted or rejected after being inspected.
+All enabled request inspectors will be executed for each request.
+If at least one returns `false` the request will be rejected.
 
 An inspector is an implementation of the following interface:
 ```java
@@ -63,7 +65,20 @@ public interface RequestInspector {
 }
 ```
 
-The implementation must be a named component, e.g.:
+- `inspectRelayedHttpRequest` is called before the relayed HTTP request is forwarded to the target.
+  If the implementation returns `false` the client will receive a `403` response.
+
+
+- `inspectWebSocketUpgradeRequest` is called before the listener accepts the relayed WebSocket connection.
+  If the implementation returns `false`, the listener will deny the WebSocket upgrade request.
+  Azure Relay expects a response in less than 30 seconds; if an inspector blocks the requests for longer than that, the client will receive a timeout.
+
+
+
+
+
+
+ - The implementation must be a named component, e.g.:
 
 ```java
 @Component(InspectorNameConstants.HEADERS_LOGGER)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ The Terra Azure Relay Listener establishes a bi-directional channel with Azure R
 
 `targetProperties.targetHost:` The local or private endpoint where the listener must forward all requests.
 
+`requestInspectors:` A list of request inspectors to be enabled.
+
 ## Running Jupyter Notebooks
 
 To enable access to a Jupyter Notebooks server instance via Azure Relay using the listener,
@@ -44,7 +46,37 @@ c.ServerApp.allow_origin = '*'
 c.ServerApp.base_url = '/qi-2-16/'
 c.ServerApp.websocket_url = 'wss://qi-relay.servicebus.windows.net/$hc/qi-2-16'
 ```
+## Request Inspectors
 
+
+The listener enables the inspection of the relayed HTTP requests.
+HTTP requests could be accepted or rejected after being inspected.
+
+An inspector is an implementation of the following interface:
+```java
+public interface RequestInspector {
+
+  public boolean inspectWebSocketUpgradeRequest(
+      RelayedHttpListenerRequest relayedHttpListenerRequest);
+
+  public boolean inspectRelayedHttpRequest(RelayedHttpListenerRequest relayedHttpListenerRequest);
+}
+```
+
+The implementation must be a named component, e.g.:
+
+```java
+@Component(InspectorNameConstants.HEADERS_LOGGER)
+public class HeaderLoggerInspector implements RequestInspector {...}
+```
+
+For a new inspector, an entry must be added to:
+
+```java
+public enum InspectorType
+```
+
+An inspector can be enabled by adding its name to the `requestInspectors` list in the configuration file.
 
 ## Additional Considerations
 

--- a/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
@@ -5,6 +5,12 @@ import com.microsoft.azure.relay.RelayConnectionStringBuilder;
 import com.microsoft.azure.relay.TokenProvider;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import org.broadinstitute.listener.relay.http.RelayedHttpRequestProcessor;
+import org.broadinstitute.listener.relay.inspectors.InspectorLocator;
+import org.broadinstitute.listener.relay.inspectors.InspectorsProcessor;
+import org.broadinstitute.listener.relay.inspectors.RequestInspector;
 import org.broadinstitute.listener.relay.transport.DefaultTargetResolver;
 import org.broadinstitute.listener.relay.transport.TargetResolver;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,13 +25,18 @@ public class AppConfiguration {
   @Autowired private ListenerProperties properties;
 
   @Bean
-  TargetResolver targetResolver() {
+  public TargetResolver targetResolver() {
     // return a simple resolver that uses the configuration value.
     return new DefaultTargetResolver(properties);
   }
 
   @Bean
-  HybridConnectionListener listener() throws URISyntaxException {
+  public RelayedHttpRequestProcessor relayedHttpRequestProcessor(TargetResolver targetResolver) {
+    return new RelayedHttpRequestProcessor(targetResolver);
+  }
+
+  @Bean
+  public HybridConnectionListener listener() throws URISyntaxException {
     RelayConnectionStringBuilder connectionParams =
         new RelayConnectionStringBuilder(properties.getRelayConnectionString());
     TokenProvider tokenProvider =
@@ -35,4 +46,24 @@ public class AppConfiguration {
         new URI(connectionParams.getEndpoint().toString() + connectionParams.getEntityPath()),
         tokenProvider);
   }
+
+  @Bean
+  public InspectorsProcessor inspectorsProcessor(InspectorLocator inspectorLocator) {
+    List<RequestInspector> inspectors = new ArrayList<>();
+
+    if (properties.getRequestInspectors() != null) {
+      properties
+          .getRequestInspectors()
+          .forEach(i -> inspectors.add(inspectorLocator.getInspector(i)));
+    }
+
+    return new InspectorsProcessor(inspectors);
+  }
+
+  //  @Bean
+  //  public List<RequestInspector> inspectors(InspectorFactory inspectorsFactory) {
+  //    var inspector = inspectorsFactory.getInspector(InspectorNameConstants.HEADERS_LOGGER);
+  //
+  //    return List.of(inspector);
+  //  }
 }

--- a/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
@@ -59,11 +59,4 @@ public class AppConfiguration {
 
     return new InspectorsProcessor(inspectors);
   }
-
-  //  @Bean
-  //  public List<RequestInspector> inspectors(InspectorFactory inspectorsFactory) {
-  //    var inspector = inspectorsFactory.getInspector(InspectorNameConstants.HEADERS_LOGGER);
-  //
-  //    return List.of(inspector);
-  //  }
 }

--- a/service/src/main/java/org/broadinstitute/listener/config/ListenerProperties.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/ListenerProperties.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.listener.config;
 
+import java.util.List;
+import org.broadinstitute.listener.relay.inspectors.InspectorType;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "listener")
@@ -8,6 +10,7 @@ public class ListenerProperties {
   private String relayConnectionString;
   private String relayConnectionName;
   private TargetProperties targetProperties;
+  private List<InspectorType> requestInspectors;
 
   public String getRelayConnectionString() {
     return relayConnectionString;
@@ -31,5 +34,13 @@ public class ListenerProperties {
 
   public void setTargetProperties(TargetProperties targetProperties) {
     this.targetProperties = targetProperties;
+  }
+
+  public List<InspectorType> getRequestInspectors() {
+    return requestInspectors;
+  }
+
+  public void setRequestInspectors(List<InspectorType> requestInspectors) {
+    this.requestInspectors = requestInspectors;
   }
 }

--- a/service/src/main/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessor.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessor.java
@@ -70,7 +70,7 @@ public class RelayedHttpRequestProcessor {
     String msg =
         String.format(
             Locale.ROOT,
-            "The listener rejected the requests. Tracking ID:%s",
+            "The listener rejected the request. Tracking ID:%s",
             context.getTrackingContext().getTrackingId());
     listenerResponse.setStatusCode(403);
     listenerResponse.setStatusDescription(msg);

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/HeaderLoggerInspector.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/HeaderLoggerInspector.java
@@ -1,0 +1,54 @@
+package org.broadinstitute.listener.relay.inspectors;
+
+import com.microsoft.azure.relay.RelayedHttpListenerRequest;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.listener.relay.inspectors.InspectorType.InspectorNameConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+
+@Component(InspectorNameConstants.HEADERS_LOGGER)
+public class HeaderLoggerInspector implements RequestInspector {
+
+  private final Logger logger = LoggerFactory.getLogger(HeaderLoggerInspector.class);
+
+  @Override
+  public boolean inspectWebSocketUpgradeRequest(
+      @NonNull RelayedHttpListenerRequest relayedHttpListenerRequest) {
+
+    logger.info("WebSocket Upgrade Request: {}", relayedHttpListenerRequest.getUri());
+
+    logHeaders(relayedHttpListenerRequest.getHeaders());
+
+    return true;
+  }
+
+  @Override
+  public boolean inspectRelayedHttpRequest(
+      @NonNull RelayedHttpListenerRequest relayedHttpListenerRequest) {
+
+    logger.info("HTTP Request: {}", relayedHttpListenerRequest.getUri());
+
+    logHeaders(relayedHttpListenerRequest.getHeaders());
+
+    return true;
+  }
+
+  private void logHeaders(Map<String, String> headers) {
+
+    if (headers == null) {
+      return;
+    }
+
+    for (Entry<String, String> header : headers.entrySet()) {
+      String value = header.getValue();
+      if (StringUtils.containsIgnoreCase(header.getKey(), "Auhtorization")) {
+        value = "*******";
+      }
+      logger.info("Header: {} Value:{}", header.getKey(), value);
+    }
+  }
+}

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/HeaderLoggerInspector.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/HeaderLoggerInspector.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.listener.relay.inspectors;
 
 import com.microsoft.azure.relay.RelayedHttpListenerRequest;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import org.apache.commons.lang3.StringUtils;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Component;
 public class HeaderLoggerInspector implements RequestInspector {
 
   private final Logger logger = LoggerFactory.getLogger(HeaderLoggerInspector.class);
+  private static final List<String> MUST_MASKED_HEADER_NAMES = List.of("Authorization", "Cookie");
 
   @Override
   public boolean inspectWebSocketUpgradeRequest(
@@ -45,10 +47,20 @@ public class HeaderLoggerInspector implements RequestInspector {
 
     for (Entry<String, String> header : headers.entrySet()) {
       String value = header.getValue();
-      if (StringUtils.containsIgnoreCase(header.getKey(), "Auhtorization")) {
+      if (isMaskedValue(header.getKey())) {
         value = "*******";
       }
       logger.info("Header: {} Value:{}", header.getKey(), value);
     }
+  }
+
+  private boolean isMaskedValue(String key) {
+    for (String maskedHeader : MUST_MASKED_HEADER_NAMES) {
+      if (StringUtils.containsIgnoreCase(key, maskedHeader)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 }

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/InspectorLocator.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/InspectorLocator.java
@@ -1,0 +1,20 @@
+package org.broadinstitute.listener.relay.inspectors;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InspectorLocator {
+
+  public final ApplicationContext context;
+
+  public InspectorLocator(ApplicationContext context) {
+    this.context = context;
+  }
+
+  public RequestInspector getInspector(InspectorType inspectorType) {
+    Object bean = context.getBean(inspectorType.getInspectorName());
+
+    return (RequestInspector) bean;
+  }
+}

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/InspectorType.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/InspectorType.java
@@ -1,0 +1,19 @@
+package org.broadinstitute.listener.relay.inspectors;
+
+public enum InspectorType {
+  HEADERS_LOGGER(InspectorNameConstants.HEADERS_LOGGER);
+
+  private final String inspectorName;
+
+  InspectorType(String inspectorName) {
+    this.inspectorName = inspectorName;
+  }
+
+  public String getInspectorName() {
+    return inspectorName;
+  }
+
+  public interface InspectorNameConstants {
+    String HEADERS_LOGGER = "headersLogger";
+  }
+}

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/InspectorsProcessor.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/InspectorsProcessor.java
@@ -51,9 +51,18 @@ public class InspectorsProcessor {
       Function<RelayedHttpListenerRequest, Set<Boolean>> distinctSet,
       RelayedHttpListenerRequest listenerRequest) {
     Set<Boolean> distinctResults = distinctSet.apply(listenerRequest);
-    boolean result = false;
-    if (distinctResults.size() == 1) {
-      result = distinctResults.iterator().next();
+    boolean result;
+    int size = distinctResults.size();
+    switch (size) {
+      case 0:
+        result = true;
+        break;
+      case 1:
+        result = distinctResults.iterator().next();
+        break;
+      default:
+        result = false;
+        break;
     }
 
     logger.info(

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/InspectorsProcessor.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/InspectorsProcessor.java
@@ -1,0 +1,92 @@
+package org.broadinstitute.listener.relay.inspectors;
+
+import com.microsoft.azure.relay.RelayedHttpListenerRequest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.lang.NonNull;
+
+public class InspectorsProcessor {
+  private final List<RequestInspector> inspectors;
+  private final Logger logger = LoggerFactory.getLogger(InspectorsProcessor.class);
+
+  public InspectorsProcessor(@NonNull List<RequestInspector> inspectors) {
+    this.inspectors = inspectors;
+  }
+
+  /**
+   * Returns true if all inspectors accept the websocket upgrade request. False is returned if at
+   * least one inspector did not accept the request.
+   *
+   * @param listenerRequest
+   * @return true or false
+   */
+  public boolean isRelayedWebSocketUpgradeRequestAccepted(
+      @NonNull RelayedHttpListenerRequest listenerRequest) {
+    return isRequestAccepted(
+        request ->
+            applyInspectorsToWebSocketUpgradeRequest(request).stream().collect(Collectors.toSet()),
+        listenerRequest);
+  }
+
+  /**
+   * Returns true if all inspectors accept the HTTP request. False is returned if at least one
+   * inspector did not accept the request.
+   *
+   * @param listenerRequest
+   * @return true or false
+   */
+  public boolean isRelayedHttpRequestAccepted(@NonNull RelayedHttpListenerRequest listenerRequest) {
+    return isRequestAccepted(
+        request ->
+            applyInspectorsToRelayedHttpRequest(request).stream().collect(Collectors.toSet()),
+        listenerRequest);
+  }
+
+  private boolean isRequestAccepted(
+      Function<RelayedHttpListenerRequest, Set<Boolean>> distinctSet,
+      RelayedHttpListenerRequest listenerRequest) {
+    Set<Boolean> distinctResults = distinctSet.apply(listenerRequest);
+    boolean result = false;
+    if (distinctResults.size() == 1) {
+      result = distinctResults.iterator().next();
+    }
+
+    logger.info(
+        "Inspection result for the HTTP request. Result: {}, URI:{}",
+        result,
+        listenerRequest.getUri());
+
+    return result;
+  }
+
+  private List<Boolean> applyInspectorsToRelayedHttpRequest(
+      RelayedHttpListenerRequest listenerRequest) {
+    List<Boolean> results = new ArrayList<>();
+
+    if (!inspectors.isEmpty()) {
+      inspectors.forEach(
+          requestInspector ->
+              results.add(requestInspector.inspectRelayedHttpRequest(listenerRequest)));
+    }
+
+    return results;
+  }
+
+  private List<Boolean> applyInspectorsToWebSocketUpgradeRequest(
+      RelayedHttpListenerRequest listenerRequest) {
+    List<Boolean> results = new ArrayList<>();
+
+    if (!inspectors.isEmpty()) {
+      inspectors.forEach(
+          requestInspector ->
+              results.add(requestInspector.inspectWebSocketUpgradeRequest(listenerRequest)));
+    }
+
+    return results;
+  }
+}

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/RequestInspector.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/RequestInspector.java
@@ -1,0 +1,11 @@
+package org.broadinstitute.listener.relay.inspectors;
+
+import com.microsoft.azure.relay.RelayedHttpListenerRequest;
+
+public interface RequestInspector {
+
+  public boolean inspectWebSocketUpgradeRequest(
+      RelayedHttpListenerRequest relayedHttpListenerRequest);
+
+  public boolean inspectRelayedHttpRequest(RelayedHttpListenerRequest relayedHttpListenerRequest);
+}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -9,3 +9,6 @@ listener:
   relayConnectionName:
   targetProperties:
     targetHost:
+  requestInspectors:
+#    - headersLogger
+

--- a/service/src/test/java/org/broadinstitute/listener/relay/http/ListenerConnectionHandlerTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/http/ListenerConnectionHandlerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import com.microsoft.azure.relay.HybridConnectionListener;
 import org.broadinstitute.listener.config.ListenerProperties;
 import org.broadinstitute.listener.config.TargetProperties;
+import org.broadinstitute.listener.relay.inspectors.InspectorsProcessor;
 import org.broadinstitute.listener.relay.transport.DefaultTargetResolver;
 import org.broadinstitute.listener.relay.transport.TargetResolver;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,6 +21,7 @@ class ListenerConnectionHandlerTest {
   private static final String TARGET_HOST = "http://localhost:8080/";
   private TargetResolver targetResolver;
   @Mock private HybridConnectionListener listener;
+  @Mock private InspectorsProcessor inspectorsProcessor;
 
   private ListenerConnectionHandler listenerConnectionHandler;
 
@@ -33,7 +35,8 @@ class ListenerConnectionHandlerTest {
 
   @Test
   void receiveRelayedHttpRequests_handlerIsSet() {
-    listenerConnectionHandler = new ListenerConnectionHandler(listener, targetResolver);
+    listenerConnectionHandler =
+        new ListenerConnectionHandler(listener, targetResolver, inspectorsProcessor);
 
     listenerConnectionHandler.receiveRelayedHttpRequests().subscribe();
 
@@ -42,7 +45,8 @@ class ListenerConnectionHandlerTest {
 
   @Test
   void openConnection_listenerConnectionOpens() {
-    listenerConnectionHandler = new ListenerConnectionHandler(listener, targetResolver);
+    listenerConnectionHandler =
+        new ListenerConnectionHandler(listener, targetResolver, inspectorsProcessor);
 
     listenerConnectionHandler.openConnection().subscribe();
 
@@ -51,7 +55,8 @@ class ListenerConnectionHandlerTest {
 
   @Test
   void closeConnection_listenerConnectionCloses() {
-    listenerConnectionHandler = new ListenerConnectionHandler(listener, targetResolver);
+    listenerConnectionHandler =
+        new ListenerConnectionHandler(listener, targetResolver, inspectorsProcessor);
 
     listenerConnectionHandler.closeConnection().subscribe();
 

--- a/service/src/test/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessorTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessorTest.java
@@ -7,12 +7,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.microsoft.azure.relay.RelayedHttpListenerContext;
+import com.microsoft.azure.relay.RelayedHttpListenerRequest;
 import com.microsoft.azure.relay.RelayedHttpListenerResponse;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
@@ -22,6 +24,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.broadinstitute.listener.relay.InvalidRelayTargetException;
+import org.broadinstitute.listener.relay.transport.TargetResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,36 +39,42 @@ class RelayedHttpRequestProcessorTest {
 
   private static final String BODY_CONTENT = "BODY";
   private static final String TARGET_URL = "http://localhost:8080/g?a=a";
-  private InputStream body;
+  private static final String TARGET_WS_URL = "ws://localhost:8080/";
+
+  private static final String RELAY_URL = "https://relay.azure.com/connection/g?a=a";
+
+  private ByteArrayInputStream body;
   private RelayedHttpRequestProcessor processor;
 
   @Mock private HttpClient httpClient;
 
   @Mock private RelayedHttpListenerContext context;
+  @Mock private RelayedHttpListenerRequest listenerRequest;
   @Mock private RelayedHttpRequest request;
   @Mock private HttpResponse targetClientResponse;
   @Mock private HttpHeaders targetResponseHttpHeaders;
   @Mock private RelayedHttpListenerResponse listenerResponse;
   @Mock private OutputStream responseStream;
   @Mock private TargetHttpResponse targetHttpResponse;
-
+  @Mock private TargetResolver targetHostResolver;
   @Captor private ArgumentCaptor<byte[]> responseData;
 
   private Map<String, List<String>> targetResponseHeaders;
   private Map<String, String> requestHeaders;
 
   @BeforeEach
-  void setUp() throws IOException, InterruptedException {
+  void setUp() {
     body = new ByteArrayInputStream(BODY_CONTENT.getBytes(StandardCharsets.UTF_8));
     targetResponseHeaders = new HashMap<>();
     targetResponseHeaders.put("RES_HEADER", List.of("RES_VALUE"));
     requestHeaders = new HashMap<>();
     requestHeaders.put("REQ_HEADER", "REQ_VALUE");
-    processor = new RelayedHttpRequestProcessor(httpClient);
+    processor = new RelayedHttpRequestProcessor(httpClient, targetHostResolver);
   }
 
   @Test
-  void executeRequestOnTarget_successfullyExecuted() throws IOException, InterruptedException {
+  void executeRequestOnTarget_successfullyExecuted()
+      throws IOException, InterruptedException, URISyntaxException, InvalidRelayTargetException {
     setUpRelayedHttpRequestMock();
     when(targetClientResponse.statusCode()).thenReturn(200);
     when(httpClient.send(any(), any())).thenReturn(targetClientResponse);
@@ -72,7 +82,7 @@ class RelayedHttpRequestProcessorTest {
     when(targetResponseHttpHeaders.map()).thenReturn(targetResponseHeaders);
     when(targetClientResponse.body()).thenReturn(body);
 
-    TargetHttpResponse response = processor.executeRequestOnTarget(request);
+    TargetHttpResponse response = processor.executeRequestOnTarget(context);
     String data = new String(response.getBody().get().readAllBytes());
 
     assertThat(response.getStatusCode(), equalTo(200));
@@ -81,10 +91,11 @@ class RelayedHttpRequestProcessorTest {
   }
 
   @Test
-  void executeRequestOnTarget_failedToExecute() throws IOException, InterruptedException {
+  void executeRequestOnTarget_failedToExecute()
+      throws IOException, InterruptedException, URISyntaxException, InvalidRelayTargetException {
     setUpRelayedHttpRequestMock();
     when(httpClient.send(any(), any())).thenThrow(new InterruptedException("Error Msg"));
-    TargetHttpResponse response = processor.executeRequestOnTarget(request);
+    TargetHttpResponse response = processor.executeRequestOnTarget(context);
 
     assertThat(response.getStatusCode(), equalTo(500));
     assertThat(response.getStatusDescription(), equalTo("Error Msg"));
@@ -105,11 +116,17 @@ class RelayedHttpRequestProcessorTest {
     assertThat(new String(responseData.getValue()), equalTo(BODY_CONTENT));
   }
 
-  private void setUpRelayedHttpRequestMock() throws MalformedURLException {
-    when(request.getTargetUrl()).thenReturn(new URL(TARGET_URL));
-    when(request.getMethod()).thenReturn("POST");
-    when(request.getBody()).thenReturn(Optional.of(body));
-    when(request.getHeaders()).thenReturn(Optional.of(requestHeaders));
-    when(request.getContext()).thenReturn(context);
+  private void setUpRelayedHttpRequestMock()
+      throws MalformedURLException, URISyntaxException, InvalidRelayTargetException {
+
+    when(targetHostResolver.createTargetUrl(any())).thenReturn(new URL(TARGET_URL));
+    when(targetHostResolver.createTargetWebSocketUri(any())).thenReturn(new URI(TARGET_WS_URL));
+
+    when(listenerRequest.getHttpMethod()).thenReturn("POST");
+    when(listenerRequest.getInputStream()).thenReturn(body);
+    when(listenerRequest.getHeaders()).thenReturn(requestHeaders);
+    when(listenerRequest.getUri()).thenReturn(new URI(RELAY_URL));
+
+    when(context.getRequest()).thenReturn(listenerRequest);
   }
 }

--- a/service/src/test/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessorTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessorTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import com.microsoft.azure.relay.RelayedHttpListenerContext;
 import com.microsoft.azure.relay.RelayedHttpListenerRequest;
 import com.microsoft.azure.relay.RelayedHttpListenerResponse;
+import com.microsoft.azure.relay.TrackingContext;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -57,6 +58,7 @@ class RelayedHttpRequestProcessorTest {
   @Mock private OutputStream responseStream;
   @Mock private TargetHttpResponse targetHttpResponse;
   @Mock private TargetResolver targetHostResolver;
+  @Mock private TrackingContext trackingContext;
   @Captor private ArgumentCaptor<byte[]> responseData;
 
   private Map<String, List<String>> targetResponseHeaders;
@@ -95,6 +97,8 @@ class RelayedHttpRequestProcessorTest {
       throws IOException, InterruptedException, URISyntaxException, InvalidRelayTargetException {
     setUpRelayedHttpRequestMock();
     when(httpClient.send(any(), any())).thenThrow(new InterruptedException("Error Msg"));
+    when(context.getTrackingContext()).thenReturn(trackingContext);
+    when(trackingContext.getTrackingId()).thenReturn("ID_1");
     TargetHttpResponse response = processor.executeRequestOnTarget(context);
 
     assertThat(response.getStatusCode(), equalTo(500));

--- a/service/src/test/java/org/broadinstitute/listener/relay/inspectors/InspectorsProcessorTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/inspectors/InspectorsProcessorTest.java
@@ -6,9 +6,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.microsoft.azure.relay.RelayedHttpListenerRequest;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -20,6 +22,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class InspectorsProcessorTest {
 
   private InspectorsProcessor inspectorsProcessor;
+  private InspectorsProcessor inspectorsProcessorNoInspectors;
+
   @Mock private RelayedHttpListenerRequest listenerRequest;
   @Mock private RequestInspector inspector1;
   @Mock private RequestInspector inspector2;
@@ -27,6 +31,7 @@ class InspectorsProcessorTest {
   @BeforeEach
   void setUp() {
     inspectorsProcessor = new InspectorsProcessor(List.of(inspector1, inspector2));
+    inspectorsProcessorNoInspectors = new InspectorsProcessor(new ArrayList<>());
   }
 
   @ParameterizedTest
@@ -59,5 +64,22 @@ class InspectorsProcessorTest {
     boolean result = inspectorsProcessor.isRelayedHttpRequestAccepted(listenerRequest);
 
     assertThat(result, equalTo(expectedResult));
+  }
+
+  @Test
+  void isRelayedHttpRequestAccepted_noInspectors() {
+
+    boolean result = inspectorsProcessorNoInspectors.isRelayedHttpRequestAccepted(listenerRequest);
+
+    assertThat(result, equalTo(true));
+  }
+
+  @Test
+  void isRelayedWebSocketUpgradeRequestAccepted_noInspectors() {
+
+    boolean result =
+        inspectorsProcessorNoInspectors.isRelayedWebSocketUpgradeRequestAccepted(listenerRequest);
+
+    assertThat(result, equalTo(true));
   }
 }

--- a/service/src/test/java/org/broadinstitute/listener/relay/inspectors/InspectorsProcessorTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/inspectors/InspectorsProcessorTest.java
@@ -1,0 +1,63 @@
+package org.broadinstitute.listener.relay.inspectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.microsoft.azure.relay.RelayedHttpListenerRequest;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InspectorsProcessorTest {
+
+  private InspectorsProcessor inspectorsProcessor;
+  @Mock private RelayedHttpListenerRequest listenerRequest;
+  @Mock private RequestInspector inspector1;
+  @Mock private RequestInspector inspector2;
+
+  @BeforeEach
+  void setUp() {
+    inspectorsProcessor = new InspectorsProcessor(List.of(inspector1, inspector2));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideInspectorScenarios")
+  void isRelayedWebSocketUpgradeRequestAccepted_scenarioIsProvided(
+      boolean firstInspector, boolean secondInspector, boolean expectedResult) {
+    when(inspector1.inspectWebSocketUpgradeRequest(any())).thenReturn(firstInspector);
+    when(inspector2.inspectWebSocketUpgradeRequest(any())).thenReturn(secondInspector);
+
+    boolean result = inspectorsProcessor.isRelayedWebSocketUpgradeRequestAccepted(listenerRequest);
+
+    assertThat(result, equalTo(expectedResult));
+  }
+
+  private static Stream<Arguments> provideInspectorScenarios() {
+    return Stream.of(
+        Arguments.of(true, true, true),
+        Arguments.of(true, false, false),
+        Arguments.of(false, true, false),
+        Arguments.of(false, false, false));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideInspectorScenarios")
+  void isRelayedHttpRequestAccepted_scenarioIsProvided(
+      boolean firstInspector, boolean secondInspector, boolean expectedResult) {
+    when(inspector1.inspectRelayedHttpRequest(any())).thenReturn(firstInspector);
+    when(inspector2.inspectRelayedHttpRequest(any())).thenReturn(secondInspector);
+
+    boolean result = inspectorsProcessor.isRelayedHttpRequestAccepted(listenerRequest);
+
+    assertThat(result, equalTo(expectedResult));
+  }
+}

--- a/service/src/test/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipelineTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipelineTest.java
@@ -1,0 +1,75 @@
+package org.broadinstitute.listener.relay.transport;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.microsoft.azure.relay.RelayedHttpListenerContext;
+import org.broadinstitute.listener.relay.http.ListenerConnectionHandler;
+import org.broadinstitute.listener.relay.http.RelayedHttpRequestProcessor;
+import org.broadinstitute.listener.relay.http.RelayedHttpRequestProcessor.Result;
+import org.broadinstitute.listener.relay.http.TargetHttpResponse;
+import org.broadinstitute.listener.relay.wss.WebSocketConnectionsHandler;
+import org.broadinstitute.listener.relay.wss.WebSocketConnectionsRelayerService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+
+@ExtendWith(MockitoExtension.class)
+class RelayedRequestPipelineTest {
+
+  @Mock private RelayedHttpListenerContext requestContext;
+  @Mock private TargetHttpResponse targetHttpResponse;
+  @Mock private ListenerConnectionHandler listenerConnectionHandler;
+  @Mock private RelayedHttpRequestProcessor relayedHttpRequestProcessor;
+  @Mock private WebSocketConnectionsHandler webSocketConnectionsHandler;
+  @Mock private WebSocketConnectionsRelayerService webSocketConnectionsRelayerService;
+
+  private RelayedRequestPipeline relayedRequestPipeline;
+
+  @BeforeEach
+  void setUp() {
+    relayedRequestPipeline =
+        new RelayedRequestPipeline(
+            listenerConnectionHandler,
+            relayedHttpRequestProcessor,
+            webSocketConnectionsHandler,
+            webSocketConnectionsRelayerService);
+  }
+
+  @Test
+  void registerHttpExecutionPipeline_isAcceptedByInspector() {
+    when(listenerConnectionHandler.receiveRelayedHttpRequests())
+        .thenReturn(Flux.create(s -> s.next(requestContext)));
+    when(listenerConnectionHandler.isRelayedHttpRequestAcceptedByInspectors(any()))
+        .thenReturn(true);
+    when(relayedHttpRequestProcessor.executeRequestOnTarget(requestContext))
+        .thenReturn(targetHttpResponse);
+    when(relayedHttpRequestProcessor.writeTargetResponseOnCaller(targetHttpResponse))
+        .thenReturn(Result.SUCCESS);
+
+    relayedRequestPipeline.registerHttpExecutionPipeline();
+
+    verify(relayedHttpRequestProcessor, times(1)).executeRequestOnTarget(requestContext);
+    verify(relayedHttpRequestProcessor, times(1)).writeTargetResponseOnCaller(targetHttpResponse);
+    verify(relayedHttpRequestProcessor, times(0)).writeNotAcceptedResponseOnCaller(any());
+  }
+
+  @Test
+  void registerHttpExecutionPipeline_isNotAcceptedByInspector() {
+    when(listenerConnectionHandler.receiveRelayedHttpRequests())
+        .thenReturn(Flux.create(s -> s.next(requestContext)));
+    when(listenerConnectionHandler.isRelayedHttpRequestAcceptedByInspectors(any()))
+        .thenReturn(false);
+
+    relayedRequestPipeline.registerHttpExecutionPipeline();
+
+    verify(relayedHttpRequestProcessor, times(0)).executeRequestOnTarget(any());
+    verify(relayedHttpRequestProcessor, times(0)).writeTargetResponseOnCaller(any());
+    verify(relayedHttpRequestProcessor, times(1)).writeNotAcceptedResponseOnCaller(requestContext);
+  }
+}

--- a/service/src/test/java/org/broadinstitute/listener/relay/wss/WebSocketConnectionsHandlerTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/wss/WebSocketConnectionsHandlerTest.java
@@ -1,0 +1,99 @@
+package org.broadinstitute.listener.relay.wss;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.microsoft.azure.relay.HybridConnectionListener;
+import com.microsoft.azure.relay.RelayedHttpListenerContext;
+import com.microsoft.azure.relay.RelayedHttpListenerRequest;
+import com.microsoft.azure.relay.TrackingContext;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.HashMap;
+import org.broadinstitute.listener.relay.InvalidRelayTargetException;
+import org.broadinstitute.listener.relay.http.RelayedHttpRequest;
+import org.broadinstitute.listener.relay.inspectors.InspectorsProcessor;
+import org.broadinstitute.listener.relay.transport.TargetResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WebSocketConnectionsHandlerTest {
+
+  private static final String TARGET_URL = "http://localhost:8080/g?a=a";
+  private static final String TARGET_WS_URL = "ws://localhost:8080/";
+
+  private static final String RELAY_URL = "https://relay.azure.com/connection/g?a=a";
+
+  @Mock(answer = Answers.CALLS_REAL_METHODS)
+  private HybridConnectionListener listener;
+
+  @Mock private RelayedHttpListenerContext context;
+  @Mock private TrackingContext trackingContext;
+  @Mock private RelayedHttpListenerRequest listenerRequest;
+  @Mock private TargetResolver targetHostResolver;
+  @Mock private InspectorsProcessor inspectorsProcessor;
+
+  private WebSocketConnectionsHandler webSocketConnectionsHandler;
+
+  @BeforeEach
+  void setUp() {
+    webSocketConnectionsHandler =
+        new WebSocketConnectionsHandler(listener, targetHostResolver, inspectorsProcessor);
+  }
+
+  @Test
+  void acceptHttpUpgradeRequests_acceptedByInspectors()
+      throws MalformedURLException, URISyntaxException, InvalidRelayTargetException {
+    setUpRelayedHttpUpgradeRequestMock();
+    when(inspectorsProcessor.isRelayedWebSocketUpgradeRequestAccepted(listenerRequest))
+        .thenReturn(true);
+
+    final RelayedHttpRequest[] relayedHttpRequests = new RelayedHttpRequest[1];
+    webSocketConnectionsHandler
+        .acceptHttpUpgradeRequests()
+        .subscribe(r -> relayedHttpRequests[0] = r);
+    boolean handlerReturn = listener.getAcceptHandler().apply(context);
+
+    assertThat(relayedHttpRequests[0].getMethod(), equalTo("GET"));
+    assertThat(handlerReturn, equalTo(true));
+  }
+
+  @Test
+  void acceptHttpUpgradeRequests_rejectedByInspectors() {
+    when(inspectorsProcessor.isRelayedWebSocketUpgradeRequestAccepted(listenerRequest))
+        .thenReturn(false);
+
+    final RelayedHttpRequest[] relayedHttpRequests = new RelayedHttpRequest[1];
+    webSocketConnectionsHandler
+        .acceptHttpUpgradeRequests()
+        .subscribe(r -> relayedHttpRequests[0] = r);
+    boolean handlerReturn = listener.getAcceptHandler().apply(context);
+
+    assertThat(relayedHttpRequests[0], equalTo(null));
+    assertThat(handlerReturn, equalTo(false));
+  }
+
+  private void setUpRelayedHttpUpgradeRequestMock()
+      throws MalformedURLException, URISyntaxException, InvalidRelayTargetException {
+
+    when(targetHostResolver.createTargetUrl(any())).thenReturn(new URL(TARGET_URL));
+    when(targetHostResolver.createTargetWebSocketUri(any())).thenReturn(new URI(TARGET_WS_URL));
+
+    when(listenerRequest.getHttpMethod()).thenReturn("GET");
+    when(listenerRequest.getHeaders()).thenReturn(new HashMap<>());
+    when(listenerRequest.getUri()).thenReturn(new URI(RELAY_URL));
+
+    when(context.getRequest()).thenReturn(listenerRequest);
+    when(context.getTrackingContext()).thenReturn(trackingContext);
+    when(trackingContext.getTrackingId()).thenReturn("ID_1");
+  }
+}


### PR DESCRIPTION
 - Enables the implementation of request inspectors.
 - The request inspectors:
   - Can accept or reject HTTP relayed requests from the client.
   - Can be enabled or disabled via configuration.
 - The PR includes an implementation that logs the HTTP headers for all the requests.