### PR TITLE
[TOA-139] Fix - Internal HTTP client defaults to HTTP 1.1

### DIFF
--- a/service/src/main/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessor.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessor.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Locale;
@@ -24,7 +25,7 @@ public class RelayedHttpRequestProcessor {
   protected final Logger logger = LoggerFactory.getLogger(RelayedHttpRequestProcessor.class);
 
   public RelayedHttpRequestProcessor(@NonNull TargetResolver targetHostResolver) {
-    this.httpClient = HttpClient.newBuilder().build();
+    this.httpClient = HttpClient.newBuilder().version(Version.HTTP_1_1).build();
     this.targetHostResolver = targetHostResolver;
   }
 


### PR DESCRIPTION
Issue Description: Currently the HTTP client is not configured to a specific HTTP version. Which results on following issues:

HTTP 2 returns headers that are not accepted by Azure Relay.

The HTTP client fails to read the response body from the target.   
 

Resolution:

Configure the default HTTP client to use HTTP 1.1. 