### PR TITLE
[TOAZ-140] Fix: Return a HTTP 500 response when requests to the target fail. 

### DIFF
--- a/service/src/main/java/org/broadinstitute/listener/relay/http/ListenerConnectionHandler.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/ListenerConnectionHandler.java
@@ -61,7 +61,7 @@ public class ListenerConnectionHandler {
                         context.getRequest().getUri(),
                         context.getTrackingContext().getTrackingId());
                     sink.next(context);
-                  } catch (Exception ex) {
+                  } catch (Throwable ex) {
                     logger.error(
                         "Error while creating relayed HTTP request. Tracking ID:{}",
                         context.getTrackingContext().getTrackingId(),

--- a/service/src/test/java/org/broadinstitute/listener/relay/http/TargetHttpResponseTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/http/TargetHttpResponseTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.when;
 
 import com.microsoft.azure.relay.RelayedHttpListenerContext;
+import com.microsoft.azure.relay.TrackingContext;
 import java.io.ByteArrayInputStream;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpResponse;
@@ -28,6 +29,8 @@ class TargetHttpResponseTest {
 
   @Mock private RelayedHttpListenerContext context;
 
+  @Mock private TrackingContext trackingContext;
+
   @Mock private ByteArrayInputStream body;
 
   @Mock private HttpResponse httpResponse;
@@ -44,13 +47,16 @@ class TargetHttpResponseTest {
   }
 
   @Test
-  void createTargetHttpResponseFromException_containsExceptionMessageAndStatusCode() {
+  void createTargetHttpResponseFromException_containsExceptionMessageStatusCodeAndBody() {
     when(exception.getMessage()).thenReturn(ERR_MSG);
+    when(context.getTrackingContext()).thenReturn(trackingContext);
+    when(trackingContext.getTrackingId()).thenReturn("123abc");
 
     targetHttpResponse =
         targetHttpResponse.createTargetHttpResponseFromException(500, exception, context);
     assertThat(targetHttpResponse.getStatusCode(), equalTo(500));
     assertThat(targetHttpResponse.getStatusDescription(), equalTo(ERR_MSG));
+    assertThat(targetHttpResponse.getBody().isPresent(), equalTo(true));
   }
 
   @Test


### PR DESCRIPTION
Issue Description: When a request to the target endpoint fails, the listener must send a 500 response to the caller. Instead, the caller is receiving gateway time out error from Azure Relay. 

Root cause: The error handling of the listener is not properly closing the relayed response body when target endpoint fails to be called. The relayed response is not closed because the body does not contain any content. Azure Relay eventually times out the request, and the caller receives a timeout error instead of a 500 response. 
 

Resolution: Add content to the response body so the relayed response is close properly.  Make sure the target response is always closed. 