### PR TITLE
[TOAZ-142] Remove hybrid connection name from the HTTP request to the target

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The Terra Azure Relay Listener establishes a bi-directional channel with Azure R
 
 `requestInspectors:` A list of request inspectors to be enabled.
 
+`targetProperties.removeEntityPathFromHttpUrl` If `true` the HTTP request to the target won't include the Entity Path (Hybrid Connection name) in the URL. The default value is `false`.
+
 ## Running Jupyter Notebooks
 
 To enable access to a Jupyter Notebooks server instance via Azure Relay using the listener,

--- a/service/src/main/java/org/broadinstitute/listener/config/TargetProperties.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/TargetProperties.java
@@ -2,6 +2,7 @@ package org.broadinstitute.listener.config;
 
 public class TargetProperties {
   private boolean removeEntityPathFromWssUri = false;
+  private boolean removeEntityPathFromHttpUrl = false;
   private String targetHost;
 
   public boolean isRemoveEntityPathFromWssUri() {
@@ -18,5 +19,13 @@ public class TargetProperties {
 
   public void setTargetHost(String targetHost) {
     this.targetHost = targetHost;
+  }
+
+  public boolean isRemoveEntityPathFromHttpUrl() {
+    return removeEntityPathFromHttpUrl;
+  }
+
+  public void setRemoveEntityPathFromHttpUrl(boolean removeEntityPathFromHttpUrl) {
+    this.removeEntityPathFromHttpUrl = removeEntityPathFromHttpUrl;
   }
 }

--- a/service/src/main/java/org/broadinstitute/listener/relay/transport/DefaultTargetResolver.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/transport/DefaultTargetResolver.java
@@ -55,7 +55,8 @@ public class DefaultTargetResolver implements TargetResolver {
   @Override
   public URL createTargetUrl(@NonNull URI relayedRequestUri) throws InvalidRelayTargetException {
 
-    return createTargetUrl(relayedRequestUri, false);
+    return createTargetUrl(
+        relayedRequestUri, properties.getTargetProperties().isRemoveEntityPathFromHttpUrl());
   }
 
   private URL createTargetUrl(URI relayedRequestUri, boolean removeEntityPath)

--- a/service/src/test/java/org/broadinstitute/listener/relay/transport/DefaultTargetResolverTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/transport/DefaultTargetResolverTest.java
@@ -76,13 +76,26 @@ class DefaultTargetResolverTest {
   }
 
   @Test
-  void createTargetUrl_requestWithPathAndQuery()
+  void createTargetUrl_requestWithPathAndQueryAndEntityPath()
       throws URISyntaxException, InvalidRelayTargetException {
     URI relayRequest = createRelayRequest(TARGET_PATH, TARGET_QS, false);
 
     URL target = resolver.createTargetUrl(relayRequest);
 
     assertThat(target.toString(), equalTo(getExpectedTargetUrl(TARGET_PATH)));
+    assertThat(target.toString().contains(HYBRID_CONN), equalTo(true));
+  }
+
+  @Test
+  void createTargetUrl_requestWithPathAndQueryAndNoEntityPath()
+      throws URISyntaxException, InvalidRelayTargetException {
+    URI relayRequest = createRelayRequest(TARGET_PATH, TARGET_QS, false);
+
+    properties.getTargetProperties().setRemoveEntityPathFromHttpUrl(true);
+
+    URL target = resolver.createTargetUrl(relayRequest);
+
+    assertThat(target.toString().contains(HYBRID_CONN), equalTo(false));
   }
 
   @Test


### PR DESCRIPTION
Issue Description: The listener adds the hybrid connection name (Entity Path) to the target URL. This behavior enables browser redirects for Jupyter. However, for APIs or other endpoints that don’t require redirection, this functionality may result in invalid requests. You can’t disable this functionality.  

Root Cause: The implementation has a flag that turns this functionality on and off, however it is not exposed as configuration property.

Resolution: Expose `removeEntityPath` as a configuration property, with a default of `false` 