### PR TITLE
BT-654 Make Sam resource type configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ that have write access to a specific Sam resource.
 `listener.samInspectorProperties.samResourceId`: The id of the Sam resource to check access to
 
 `listener.samInspectorProperties.samResourceType`: The type of the Sam resource to check access to.
-Defaults to `controlled-application-private-workspace-resource`, which corresponds to Jupyter Notebooks.
+Defaults to `controlled-application-private-workspace-resource`, which corresponds Leo-managed resources.
 
 ## Running Jupyter Notebooks
 
@@ -44,7 +44,7 @@ the following configuration settings are required.
 
 `c.NotebookApp.allow_origin = '*'`
 
-*Note*: You could add an specific Azure Relay origin if required.
+*Note*: You could add a specific Azure Relay origin if required.
 
 `c.NotebookApp.base_url = '/<HYBRID CONNECTION NAME>/'`
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ The Terra Azure Relay Listener establishes a bi-directional channel with Azure R
 
 `listener.corsSupportProperties.preflightMethods` Methods that we support CORS. Default to `OPTIONS, POST, PUT, GET, DELETE, HEAD, PATCH`.
 
+### Sam Inspector config options
+
+By using the Sam Checker inspector, the Listener can be configured to allow access only for users
+that have write access to a specific Sam resource.
+
+`listener.samInspectorProperties.samUrl`: URL to the Sam instance we should talk to
+
+`listener.samInspectorProperties.samResourceId`: The id of the Sam resource to check access to
+
+`listener.samInspectorProperties.samResourceType`: The type of the Sam resource to check access to.
+Defaults to `controlled-application-private-workspace-resource`, which corresponds to Jupyter Notebooks.
+
 ## Running Jupyter Notebooks
 
 To enable access to a Jupyter Notebooks server instance via Azure Relay using the listener,
@@ -52,7 +64,6 @@ c.ServerApp.websocket_url = 'wss://qi-relay.servicebus.windows.net/$hc/qi-2-16'
 ```
 ## Request Inspectors
 
-
 The listener enables the inspection of the relayed HTTP requests.
 HTTP requests could be accepted or rejected after being inspected.
 All enabled request inspectors will be executed for each request.
@@ -76,11 +87,6 @@ public interface RequestInspector {
 - `inspectWebSocketUpgradeRequest` is called before the listener accepts the relayed WebSocket connection.
   If the implementation returns `false`, the listener will deny the WebSocket upgrade request.
   Azure Relay expects a response in less than 30 seconds; if an inspector blocks the requests for longer than that, the client will receive a timeout.
-
-
-
-
-
 
  - The implementation must be a named component, e.g.:
 

--- a/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
@@ -38,10 +38,13 @@ public class AppConfiguration {
   @Bean
   public SamResourceClient samResourceClient() {
     ApiClient samClient = new ApiClient();
-    samClient.setBasePath(properties.getSamInspectorProperties().samUrl());
+    samClient.setBasePath(properties.getSamInspectorProperties().getSamUrl());
     // return a simple resolver that uses the configuration value.
     return new SamResourceClient(
-        properties.getSamInspectorProperties().samResourceId(), samClient, new TokenChecker());
+        properties.getSamInspectorProperties().getSamResourceId(),
+        properties.getSamInspectorProperties().getSamResourceType(),
+        samClient,
+        new TokenChecker());
   }
 
   @Bean

--- a/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
@@ -38,11 +38,11 @@ public class AppConfiguration {
   @Bean
   public SamResourceClient samResourceClient() {
     ApiClient samClient = new ApiClient();
-    samClient.setBasePath(properties.getSamInspectorProperties().getSamUrl());
+    samClient.setBasePath(properties.getSamInspectorProperties().samUrl());
     // return a simple resolver that uses the configuration value.
     return new SamResourceClient(
-        properties.getSamInspectorProperties().getSamResourceId(),
-        properties.getSamInspectorProperties().getSamResourceType(),
+        properties.getSamInspectorProperties().samResourceId(),
+        properties.getSamInspectorProperties().samResourceType(),
         samClient,
         new TokenChecker());
   }

--- a/service/src/main/java/org/broadinstitute/listener/config/SamInspectorProperties.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/SamInspectorProperties.java
@@ -1,3 +1,31 @@
 package org.broadinstitute.listener.config;
 
-public record SamInspectorProperties(String samUrl, String samResourceId) {}
+public class SamInspectorProperties {
+  private String samUrl;
+  private String samResourceId;
+  private String samResourceType = "controlled-application-private-workspace-resource";
+
+  public String getSamUrl() {
+    return samUrl;
+  }
+
+  public void setSamUrl(String samUrl) {
+    this.samUrl = samUrl;
+  }
+
+  public String getSamResourceId() {
+    return samResourceId;
+  }
+
+  public void setSamResourceId(String samResourceId) {
+    this.samResourceId = samResourceId;
+  }
+
+  public String getSamResourceType() {
+    return samResourceType;
+  }
+
+  public void setSamResourceType(String samResourceType) {
+    this.samResourceType = samResourceType;
+  }
+}

--- a/service/src/main/java/org/broadinstitute/listener/config/SamInspectorProperties.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/SamInspectorProperties.java
@@ -1,31 +1,3 @@
 package org.broadinstitute.listener.config;
 
-public class SamInspectorProperties {
-  private String samUrl;
-  private String samResourceId;
-  private String samResourceType = "controlled-application-private-workspace-resource";
-
-  public String getSamUrl() {
-    return samUrl;
-  }
-
-  public void setSamUrl(String samUrl) {
-    this.samUrl = samUrl;
-  }
-
-  public String getSamResourceId() {
-    return samResourceId;
-  }
-
-  public void setSamResourceId(String samResourceId) {
-    this.samResourceId = samResourceId;
-  }
-
-  public String getSamResourceType() {
-    return samResourceType;
-  }
-
-  public void setSamResourceType(String samResourceType) {
-    this.samResourceType = samResourceType;
-  }
-}
+public record SamInspectorProperties(String samUrl, String samResourceId, String samResourceType) {}

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SamResourceClient.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SamResourceClient.java
@@ -11,15 +11,19 @@ import org.springframework.cache.annotation.Cacheable;
 
 public class SamResourceClient {
   private final String samResourceId;
+  private final String samResourceType;
   private final TokenChecker tokenChecker;
   private final ApiClient samClient;
 
-  private final String SAM_RESOURCE_TYPE = "controlled-application-private-workspace-resource";
-
   private final Logger logger = LoggerFactory.getLogger(SamResourceClient.class);
 
-  public SamResourceClient(String samResourceId, ApiClient samClient, TokenChecker tokenChecker) {
+  public SamResourceClient(
+      String samResourceId,
+      String samResourceType,
+      ApiClient samClient,
+      TokenChecker tokenChecker) {
     this.samResourceId = samResourceId;
+    this.samResourceType = samResourceType;
     this.tokenChecker = tokenChecker;
     this.samClient = samClient;
   }
@@ -34,7 +38,7 @@ public class SamResourceClient {
         samClient.setAccessToken(accessToken);
         var resourceApi = new ResourcesApi(samClient);
 
-        var res = resourceApi.resourcePermissionV2(SAM_RESOURCE_TYPE, samResourceId, "write");
+        var res = resourceApi.resourcePermissionV2(samResourceType, samResourceId, "write");
         if (res) return oauthInfo.expiresAt().get();
         else {
           logger.error("unauthorized request");

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -18,6 +18,7 @@ listener:
   samInspectorProperties:
     samUrl:
     samResourceId:
+    samResourceType: "controlled-application-private-workspace-resource"
   corsSupportProperties:
     preflightMethods: "OPTIONS, POST, PUT, GET, DELETE, HEAD, PATCH"
     allowHeaders: "Authorization, Content-Type, Accept, Origin,X-App-Id"

--- a/service/src/test/java/org/broadinstitute/listener/relay/inspectors/SamResourceClientTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/inspectors/SamResourceClientTest.java
@@ -28,7 +28,8 @@ class SamResourceClientTest {
 
   @BeforeEach
   void setUp() throws IOException, InterruptedException, ApiException {
-    samResourceClient = new SamResourceClient("resourceId", apiClient, tokenChecker);
+    samResourceClient =
+        new SamResourceClient("resourceId", "resourceType", apiClient, tokenChecker);
   }
 
   @Test


### PR DESCRIPTION
I tested this by deploying it to our Cromwell app using the changes in https://github.com/broadinstitute/cromwhelm/pull/31 and configuring it to use workspace access when checking permission.

Unsure whether retaining the old sam resource type value as a default is valuable, I just didn't want Leo's use of this to break. 