### PR TITLE
IA-3490 add CSP in responses

### DIFF
--- a/service/src/main/java/org/broadinstitute/listener/config/CorsSupportProperties.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/CorsSupportProperties.java
@@ -1,3 +1,4 @@
 package org.broadinstitute.listener.config;
 
-public record CorsSupportProperties(String preflightMethods, String allowHeaders, String maxAge) {}
+public record CorsSupportProperties(
+    String preflightMethods, String allowHeaders, String maxAge, String contentSecurityPolicy) {}

--- a/service/src/main/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessor.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessor.java
@@ -5,6 +5,7 @@ import static com.google.common.net.HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS;
 import static com.google.common.net.HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS;
 import static com.google.common.net.HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN;
 import static com.google.common.net.HttpHeaders.ACCESS_CONTROL_MAX_AGE;
+import static com.google.common.net.HttpHeaders.CONTENT_SECURITY_POLICY;
 import static com.google.common.net.HttpHeaders.SET_COOKIE;
 
 import com.microsoft.azure.relay.RelayedHttpListenerContext;
@@ -73,7 +74,8 @@ public class RelayedHttpRequestProcessor {
 
       clientResponse = httpClient.send(localRequest, HttpResponse.BodyHandlers.ofInputStream());
 
-      return TargetHttpResponse.createTargetHttpResponse(clientResponse, request.getContext());
+      return TargetHttpResponse.createTargetHttpResponse(
+          clientResponse, request.getContext(), corsSupportProperties);
 
     } catch (Throwable ex) {
 
@@ -234,6 +236,9 @@ public class RelayedHttpRequestProcessor {
     listenerResponse.getHeaders().put(ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
     listenerResponse
         .getHeaders()
+        .put(CONTENT_SECURITY_POLICY, corsSupportProperties.contentSecurityPolicy());
+    listenerResponse
+        .getHeaders()
         .put(ACCESS_CONTROL_ALLOW_HEADERS, corsSupportProperties.allowHeaders());
     listenerResponse.getHeaders().put(ACCESS_CONTROL_MAX_AGE, corsSupportProperties.maxAge());
   }
@@ -251,7 +256,8 @@ public class RelayedHttpRequestProcessor {
             "Relayed request failed. Tracking ID:%s",
             context.getTrackingContext().getTrackingId());
     logger.error(message, exception);
-    return TargetHttpResponse.createTargetHttpResponseFromException(500, exception, context);
+    return TargetHttpResponse.createTargetHttpResponseFromException(
+        500, exception, context, corsSupportProperties);
   }
 
   private HttpRequest toClientHttpRequest(RelayedHttpRequest request) throws URISyntaxException {

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -23,3 +23,4 @@ listener:
     preflightMethods: "OPTIONS, POST, PUT, GET, DELETE, HEAD, PATCH"
     allowHeaders: "Authorization, Content-Type, Accept, Origin,X-App-Id"
     maxAge: "1728000"
+    contentSecurityPolicy: "frame-ancestors http://localhost:3000;report-uri https://terra.report-uri.com/r/d/csp/reportOnly"

--- a/service/src/test/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessorTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessorTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.listener.relay.http;
 
+import static com.google.common.net.HttpHeaders.CONTENT_SECURITY_POLICY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
@@ -81,7 +82,7 @@ class RelayedHttpRequestProcessorTest {
         new RelayedHttpRequestProcessor(
             httpClient,
             targetHostResolver,
-            new CorsSupportProperties("dummy", "dummy", "dummy"),
+            new CorsSupportProperties("dummy", "dummy", "dummy", "dummy"),
             new TokenChecker());
   }
 
@@ -99,6 +100,7 @@ class RelayedHttpRequestProcessorTest {
     String data = new String(response.getBody().get().readAllBytes());
 
     assertThat(response.getStatusCode(), equalTo(200));
+    targetResponseHeaders.put(CONTENT_SECURITY_POLICY, List.of("dummy"));
     assertThat(response.getHeaders().get().keySet(), equalTo(targetResponseHeaders.keySet()));
     assertThat(data, equalTo(BODY_CONTENT));
   }

--- a/service/src/test/java/org/broadinstitute/listener/relay/http/TargetHttpResponseTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/http/TargetHttpResponseTest.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.listener.relay.http;
 
+import static com.google.common.net.HttpHeaders.CONTENT_SECURITY_POLICY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.when;
@@ -73,6 +74,7 @@ class TargetHttpResponseTest {
             httpResponse, context, new CorsSupportProperties("", "", " ", ""));
     assertThat(targetHttpResponse.getStatusCode(), equalTo(200));
     assertThat(targetHttpResponse.getBody().get(), equalTo(body));
+    headers.put(CONTENT_SECURITY_POLICY, List.of("dummy"));
     assertThat(targetHttpResponse.getHeaders().get().keySet(), equalTo(headers.keySet()));
     assertThat(targetHttpResponse.getContext(), equalTo(context));
   }

--- a/service/src/test/java/org/broadinstitute/listener/relay/http/TargetHttpResponseTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/http/TargetHttpResponseTest.java
@@ -12,6 +12,7 @@ import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.broadinstitute.listener.config.CorsSupportProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,7 +54,8 @@ class TargetHttpResponseTest {
     when(trackingContext.getTrackingId()).thenReturn("123abc");
 
     targetHttpResponse =
-        targetHttpResponse.createTargetHttpResponseFromException(500, exception, context);
+        targetHttpResponse.createTargetHttpResponseFromException(
+            500, exception, context, new CorsSupportProperties("", "", " ", ""));
     assertThat(targetHttpResponse.getStatusCode(), equalTo(500));
     assertThat(targetHttpResponse.getStatusDescription(), equalTo(ERR_MSG));
     assertThat(targetHttpResponse.getBody().isPresent(), equalTo(true));
@@ -66,7 +68,9 @@ class TargetHttpResponseTest {
     when(httpResponse.headers()).thenReturn(httpHeaders);
     when(httpResponse.statusCode()).thenReturn(200);
 
-    targetHttpResponse = targetHttpResponse.createTargetHttpResponse(httpResponse, context);
+    targetHttpResponse =
+        targetHttpResponse.createTargetHttpResponse(
+            httpResponse, context, new CorsSupportProperties("", "", " ", ""));
     assertThat(targetHttpResponse.getStatusCode(), equalTo(200));
     assertThat(targetHttpResponse.getBody().get(), equalTo(body));
     assertThat(targetHttpResponse.getHeaders().get().keySet(), equalTo(headers.keySet()));

--- a/service/src/test/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipelineTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipelineTest.java
@@ -53,6 +53,7 @@ class RelayedRequestPipelineTest {
     when(listenerConnectionHandler.isRelayedHttpRequestAcceptedByInspectors(any()))
         .thenReturn(true);
     when(listenerConnectionHandler.isNotPreflight(any())).thenReturn(true);
+    when(listenerConnectionHandler.isNotSetCookie(any())).thenReturn(true);
     when(relayedHttpRequestProcessor.executeRequestOnTarget(requestContext))
         .thenReturn(targetHttpResponse);
     when(relayedHttpRequestProcessor.writeTargetResponseOnCaller(targetHttpResponse))
@@ -69,6 +70,8 @@ class RelayedRequestPipelineTest {
   void registerHttpExecutionPipeline_isNotAcceptedByInspector() {
     when(listenerConnectionHandler.receiveRelayedHttpRequests())
         .thenReturn(Flux.create(s -> s.next(requestContext)));
+    when(listenerConnectionHandler.isNotPreflight(any())).thenReturn(true);
+    when(listenerConnectionHandler.isNotSetCookie(any())).thenReturn(true);
     when(listenerConnectionHandler.isRelayedHttpRequestAcceptedByInspectors(any()))
         .thenReturn(false);
     when(listenerConnectionHandler.isNotPreflight(any())).thenReturn(true);


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3490

* Add `content-security-policy` in responses
* Append `Secure; SameSite=None` in jupyterlab's set-cookie response header

Tested locally and things are working finally!
![Screen Shot 2022-06-10 at 10 03 53 AM](https://user-images.githubusercontent.com/32771737/173083617-2bd58c7e-6b71-4013-b346-dc1bfb4c712d.png)


 