### PR TITLE
IA-3698 Implementation of routing rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The Terra Azure Relay Listener establishes a bi-directional channel with Azure R
 
 `listener.corsSupportProperties.preflightMethods` Methods that we support CORS. Default to `OPTIONS, POST, PUT, GET, DELETE, HEAD, PATCH`.
 
-`listener.targetProperties.targetRoutingRules` As list of target routing rules. A rule is a tuple of the string to look in the URI and the target host.
+`listener.targetProperties.targetRoutingRules` A list of routing rules. A rule is a tuple of the string the URI must contain for a match and the target host.
 The default `targetHost` is used. Example configuration:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -26,7 +26,12 @@ The Terra Azure Relay Listener establishes a bi-directional channel with Azure R
 `listener.corsSupportProperties.preflightMethods` Methods that we support CORS. Default to `OPTIONS, POST, PUT, GET, DELETE, HEAD, PATCH`.
 
 `listener.targetProperties.targetRoutingRules` A list of routing rules. A rule is a tuple of the string the URI must contain for a match and the target host.
-The default `targetHost` is used. Example configuration:
+The default `targetHost` is used if the request URI does not match any rule.
+
+In a rule, you can specify path segments the listener must remove when creating the target URI
+by using the property `removeFromPath`. In the value, you can use `$hc-name` to represent the hybrid connection name (entity path) as a segment to remove. The listener replaces `$hc-name` with the value in `relayConnectionName` to construct the string to find in the URI at runtime.
+
+Example configuration:
 
 ```yaml
   targetProperties:
@@ -34,7 +39,8 @@ The default `targetHost` is used. Example configuration:
     targetRoutingRules:
       -
         pathContains: "welder"
-        targetHost: "http://localhsot:8081"
+        targetHost: "http://localhost:8081"
+        removeFromPath: "$hc-name/welder"
 ```
 ### Sam Inspector config options
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Terra Azure Relay Listener establishes a bi-directional channel with Azure R
 
 `relayConnectionName`: Hybrid Connection name. Must the same value as the EntityPath.
 
-`listener.targetProperties.targetHost`: The local or private endpoint where the listener must forward all requests.
+`listener.targetProperties.targetHost`: The default local or private endpoint where the listener must forward all requests.
 
 `requestInspectors`: A list of request inspectors to be enabled.
 
@@ -25,6 +25,17 @@ The Terra Azure Relay Listener establishes a bi-directional channel with Azure R
 
 `listener.corsSupportProperties.preflightMethods` Methods that we support CORS. Default to `OPTIONS, POST, PUT, GET, DELETE, HEAD, PATCH`.
 
+`listener.targetProperties.targetRoutingRules` As list of target routing rules. A rule is a tuple of the string to look in the URI and the target host.
+The default `targetHost` is used. Example configuration:
+
+```yaml
+  targetProperties:
+    targetHost: "http://localhost:8080"
+    targetRoutingRules:
+      -
+        pathContains: "welder"
+        targetHost: "http://localhsot:8081"
+```
 ### Sam Inspector config options
 
 By using the Sam Checker inspector, the Listener can be configured to allow access only for users

--- a/service/src/main/java/org/broadinstitute/listener/config/TargetProperties.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/TargetProperties.java
@@ -1,9 +1,12 @@
 package org.broadinstitute.listener.config;
 
+import java.util.List;
+
 public class TargetProperties {
   private boolean removeEntityPathFromWssUri = false;
   private boolean removeEntityPathFromHttpUrl = false;
   private String targetHost;
+  private List<TargetRoutingRule> targetRoutingRules;
 
   public boolean isRemoveEntityPathFromWssUri() {
     return removeEntityPathFromWssUri;
@@ -27,5 +30,13 @@ public class TargetProperties {
 
   public void setRemoveEntityPathFromHttpUrl(boolean removeEntityPathFromHttpUrl) {
     this.removeEntityPathFromHttpUrl = removeEntityPathFromHttpUrl;
+  }
+
+  public List<TargetRoutingRule> getTargetRoutingRules() {
+    return targetRoutingRules;
+  }
+
+  public void setTargetRoutingRules(List<TargetRoutingRule> targetRoutingRules) {
+    this.targetRoutingRules = targetRoutingRules;
   }
 }

--- a/service/src/main/java/org/broadinstitute/listener/config/TargetRoutingRule.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/TargetRoutingRule.java
@@ -1,0 +1,3 @@
+package org.broadinstitute.listener.config;
+
+public record TargetRoutingRule(String pathContains, String targetHost) {}

--- a/service/src/main/java/org/broadinstitute/listener/config/TargetRoutingRule.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/TargetRoutingRule.java
@@ -1,3 +1,3 @@
 package org.broadinstitute.listener.config;
 
-public record TargetRoutingRule(String pathContains, String targetHost) {}
+public record TargetRoutingRule(String pathContains, String targetHost, String removeFromPath) {}

--- a/service/src/main/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessor.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessor.java
@@ -72,6 +72,8 @@ public class RelayedHttpRequestProcessor {
 
       HttpRequest localRequest = toClientHttpRequest(request);
 
+      logger.info("Local request: {}", localRequest.uri().toString());
+
       clientResponse = httpClient.send(localRequest, HttpResponse.BodyHandlers.ofInputStream());
 
       return TargetHttpResponse.createTargetHttpResponse(

--- a/service/src/main/java/org/broadinstitute/listener/relay/transport/DefaultTargetResolver.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/transport/DefaultTargetResolver.java
@@ -10,7 +10,7 @@ import org.broadinstitute.listener.relay.InvalidRelayTargetException;
 import org.springframework.lang.NonNull;
 
 public class DefaultTargetResolver implements TargetResolver {
-  public static String HC_NAME_RULE_WILD_CARD = "$hc-name";
+  public static final String HC_NAME_RULE_WILD_CARD = "$hc-name";
   private final String defaultTargetHost;
   private final ListenerProperties properties;
 

--- a/service/src/main/java/org/broadinstitute/listener/relay/transport/DefaultTargetResolver.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/transport/DefaultTargetResolver.java
@@ -2,22 +2,15 @@ package org.broadinstitute.listener.relay.transport;
 
 import java.net.URI;
 import java.net.URL;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.client.utils.URIBuilder;
 import org.broadinstitute.listener.config.ListenerProperties;
 import org.broadinstitute.listener.config.TargetRoutingRule;
 import org.broadinstitute.listener.relay.InvalidRelayTargetException;
 import org.springframework.lang.NonNull;
-import org.springframework.web.util.UriUtils;
 
 public class DefaultTargetResolver implements TargetResolver {
-  private static final String WS_HC_SEGMENT = "/$hc";
-
+  public static String HC_NAME_RULE_WILD_CARD = "$hc-name";
   private final String defaultTargetHost;
   private final ListenerProperties properties;
 
@@ -56,54 +49,48 @@ public class DefaultTargetResolver implements TargetResolver {
         relayedRequestUri, properties.getTargetProperties().isRemoveEntityPathFromHttpUrl());
   }
 
-  private String resolveTargetHostUsingRules(@NonNull URI relayedRequestUri) {
+  private TargetRule resolveTargetRule(@NonNull URI relayedRequestUri, boolean removeEntityPath) {
     List<TargetRoutingRule> rules = properties.getTargetProperties().getTargetRoutingRules();
     if (rules == null || rules.size() == 0) {
-      return defaultTargetHost;
+      return getDefaultRule(removeEntityPath);
     }
-    Optional<String> ruleTargetHost =
-        rules.stream()
-            .filter(r -> relayedRequestUri.toString().contains(r.pathContains()))
-            .map(r -> r.targetHost())
-            .findFirst();
+    return rules.stream()
+        .filter(r -> relayedRequestUri.toString().contains(r.pathContains()))
+        .map(this::createTargetRule)
+        .findFirst()
+        .orElse(getDefaultRule(removeEntityPath));
+  }
 
-    if (ruleTargetHost.isPresent()) {
-      return ruleTargetHost.get();
+  private TargetRule createTargetRule(TargetRoutingRule configurationRule) {
+
+    String segmentToRemove = replaceHybridConnWildCardWithConnectionName(configurationRule);
+
+    return new TargetRule(configurationRule.targetHost(), segmentToRemove);
+  }
+
+  private String replaceHybridConnWildCardWithConnectionName(TargetRoutingRule configurationRule) {
+    String segmentToRemove =
+        configurationRule
+            .removeFromPath()
+            .replace(HC_NAME_RULE_WILD_CARD, properties.getRelayConnectionName());
+    return segmentToRemove;
+  }
+
+  private TargetRule getDefaultRule(boolean removeEntityPath) {
+    String segmentsToRemove = "";
+    if (removeEntityPath) {
+      segmentsToRemove = properties.getRelayConnectionName();
     }
-    return defaultTargetHost;
+    return new TargetRule(defaultTargetHost, segmentsToRemove);
   }
 
   private URL createTargetUrl(URI relayedRequestUri, boolean removeEntityPath)
       throws InvalidRelayTargetException {
 
-    // remove the WSS segment from the URI
-    String path = relayedRequestUri.getPath().replace(WS_HC_SEGMENT, "");
+    TargetRule rule = resolveTargetRule(relayedRequestUri, removeEntityPath);
 
-    // remove trailing slash from the host and the leading slash for the path
-    path = StringUtils.stripStart(path, "/");
-    String host = StringUtils.stripEnd(resolveTargetHostUsingRules(relayedRequestUri), "/");
+    TargetURIParser parser = new TargetURIParser(rule.targetHost(), relayedRequestUri);
 
-    String query = "";
-    if (StringUtils.isNotBlank(relayedRequestUri.getQuery())) {
-
-      query = "?" + relayedRequestUri.getQuery();
-    }
-
-    try {
-      path = UriUtils.encodePath(path, "UTF-8");
-      if (removeEntityPath) {
-        path = Arrays.stream(path.split("/")).skip(1).collect(Collectors.joining("/"));
-      }
-      URIBuilder builder = new URIBuilder(String.format(Locale.ROOT, "%s/%s%s", host, path, query));
-
-      return builder.build().toURL();
-    } catch (Exception e) {
-      throw new InvalidRelayTargetException(
-          String.format(
-              Locale.ROOT,
-              "The target URL could not be parsed. Request URI: %s",
-              relayedRequestUri),
-          e);
-    }
+    return parser.parseTargetHttpUrl(rule.segmentsToRemove());
   }
 }

--- a/service/src/main/java/org/broadinstitute/listener/relay/transport/DefaultTargetResolver.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/transport/DefaultTargetResolver.java
@@ -31,12 +31,6 @@ public class DefaultTargetResolver implements TargetResolver {
   }
 
   @Override
-  public String resolveTargetHost() {
-
-    return defaultTargetHost;
-  }
-
-  @Override
   public URI createTargetWebSocketUri(@NonNull URI relayedRequestUri)
       throws InvalidRelayTargetException {
     URL targetUrl =

--- a/service/src/main/java/org/broadinstitute/listener/relay/transport/TargetResolver.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/transport/TargetResolver.java
@@ -7,8 +7,6 @@ import org.springframework.lang.NonNull;
 
 public interface TargetResolver {
 
-  String resolveTargetHost();
-
   URL createTargetUrl(@NonNull URI relayedRequestUri) throws InvalidRelayTargetException;
 
   URI createTargetWebSocketUri(@NonNull URI relayedRequestUri) throws InvalidRelayTargetException;

--- a/service/src/main/java/org/broadinstitute/listener/relay/transport/TargetRule.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/transport/TargetRule.java
@@ -1,0 +1,3 @@
+package org.broadinstitute.listener.relay.transport;
+
+public record TargetRule(String targetHost, String segmentsToRemove) {}

--- a/service/src/main/java/org/broadinstitute/listener/relay/transport/TargetURIParser.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/transport/TargetURIParser.java
@@ -1,0 +1,80 @@
+package org.broadinstitute.listener.relay.transport;
+
+import java.net.URI;
+import java.net.URL;
+import java.util.Locale;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.client.utils.URIBuilder;
+import org.broadinstitute.listener.relay.InvalidRelayTargetException;
+import org.springframework.web.util.UriUtils;
+
+public class TargetURIParser {
+  private static final String WS_HC_SEGMENT = "/$hc";
+
+  private final String targetHost;
+  private final URI relayedRequestUri;
+
+  public TargetURIParser(String targetHost, URI relayedRequestUri) {
+    this.targetHost = targetHost;
+    this.relayedRequestUri = relayedRequestUri;
+  }
+
+  public URL parseTargetHttpUrl(String segmentsToRemove) throws InvalidRelayTargetException {
+
+    // remove trailing slash from the host
+    String host = StringUtils.stripEnd(targetHost, "/");
+
+    String query = parseQuery();
+
+    try {
+      String path = parsePath(segmentsToRemove);
+      URIBuilder builder = new URIBuilder(String.format(Locale.ROOT, "%s/%s%s", host, path, query));
+
+      return builder.build().toURL();
+    } catch (Exception e) {
+      throw new InvalidRelayTargetException(
+          String.format(
+              Locale.ROOT,
+              "The target URL could not be parsed. Request URI: %s",
+              relayedRequestUri),
+          e);
+    }
+  }
+
+  private String parseQuery() {
+    String query = "";
+    if (StringUtils.isNotBlank(relayedRequestUri.getQuery())) {
+
+      query = "?" + relayedRequestUri.getQuery();
+    }
+    return query;
+  }
+
+  private String parsePath(String segmentsToRemove) {
+
+    // A client establishes a ws connection to Azure Relay to different URL.
+    // The URL contains an additional segment: $hc. This segment is not expected in the
+    // target, therefore it must be removed.
+    String path = removeSegmentsFromPath(WS_HC_SEGMENT, relayedRequestUri.getPath());
+
+    if (StringUtils.isNotBlank(segmentsToRemove)) {
+      path = removeSegmentsFromPath(segmentsToRemove, path);
+    }
+    path = UriUtils.encodePath(path, "UTF-8");
+
+    return path;
+  }
+
+  private String removeSegmentsFromPath(String segmentsToRemove, String path) {
+    String segments = stripEndAndStartChar(segmentsToRemove, "/");
+    String parsedPath = path.replace(segments, "").replace("//", "/");
+    parsedPath = stripEndAndStartChar(parsedPath, "/");
+    return parsedPath;
+  }
+
+  private String stripEndAndStartChar(String segmentsToRemove, String stripChar) {
+    String segments = StringUtils.stripStart(segmentsToRemove, stripChar);
+    segments = StringUtils.stripEnd(segments, stripChar);
+    return segments;
+  }
+}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -11,7 +11,12 @@ listener:
   relayConnectionString:
   relayConnectionName:
   targetProperties:
-    targetHost:
+    targetHost: "http://localhost:8080"
+    targetRoutingRules:
+      -
+        pathContains: "welder"
+        targetHost: "http://localhost:8081"
+        removeFromPath: "$hc-name/welder"
   requestInspectors:
 #    - headersLogger
     - samChecker

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -11,7 +11,7 @@ listener:
   relayConnectionString:
   relayConnectionName:
   targetProperties:
-    targetHost: "http://localhost:8080"
+    targetHost:
     targetRoutingRules:
       -
         pathContains: "welder"

--- a/service/src/test/java/org/broadinstitute/listener/relay/transport/DefaultTargetResolverTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/transport/DefaultTargetResolverTest.java
@@ -56,12 +56,6 @@ class DefaultTargetResolverTest {
   }
 
   @Test
-  void resolveTargetHost_returnsConfigurationValue() {
-    assertThat(
-        resolver.resolveTargetHost(), equalTo(properties.getTargetProperties().getTargetHost()));
-  }
-
-  @Test
   void createTargetWebSocketUri_requestWithPathAndQueryNoEntityPath()
       throws URISyntaxException, InvalidRelayTargetException {
     URI relayRequest = createRelayRequest(TARGET_PATH, TARGET_QS, false);

--- a/service/src/test/java/org/broadinstitute/listener/relay/transport/TargetURIParserTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/transport/TargetURIParserTest.java
@@ -1,0 +1,66 @@
+package org.broadinstitute.listener.relay.transport;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.stream.Stream;
+import org.apache.http.client.utils.URIBuilder;
+import org.broadinstitute.listener.relay.InvalidRelayTargetException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class TargetURIParserTest {
+
+  private TargetURIParser targetURIParser;
+  private static final String TARGET_HOST = "https://localhost:8080";
+
+  @ParameterizedTest
+  @MethodSource("parseScenarios")
+  void parseTargetHttpUrl_scenarioWithTargetHostWithoutEndingSlash(
+      String relayedURI, String segmentsToRemove, String expectedTarget)
+      throws InvalidRelayTargetException, URISyntaxException {
+    URIBuilder builder = new URIBuilder(relayedURI);
+    targetURIParser = new TargetURIParser(TARGET_HOST, builder.build());
+    URL result = targetURIParser.parseTargetHttpUrl(segmentsToRemove);
+
+    assertThat(result.toString(), equalTo(expectedTarget));
+  }
+
+  @ParameterizedTest
+  @MethodSource("parseScenarios")
+  void parseTargetHttpUrl_scenarioWithTargetHostWithEndingSlash(
+      String relayedURI, String segmentsToRemove, String expectedTarget)
+      throws InvalidRelayTargetException, URISyntaxException {
+    URIBuilder builder = new URIBuilder(relayedURI);
+    targetURIParser = new TargetURIParser(TARGET_HOST + "/", builder.build());
+    URL result = targetURIParser.parseTargetHttpUrl(segmentsToRemove);
+
+    assertThat(result.toString(), equalTo(expectedTarget));
+  }
+
+  private static Stream<Arguments> parseScenarios() {
+    return Stream.of(
+        Arguments.of("https://r/c/p1/p2?q=1", "", TARGET_HOST + "/c/p1/p2?q=1"),
+        Arguments.of("https://r/c/p1/p2?q=1", "p1/p3", TARGET_HOST + "/c/p1/p2?q=1"),
+        Arguments.of("https://r/c/p1/p2?q=1", "c/p2", TARGET_HOST + "/c/p1/p2?q=1"),
+        Arguments.of("https://r/c/p1/p2?q=1", "c/p1", TARGET_HOST + "/p2?q=1"),
+        Arguments.of("https://r/c/p1/p2?q=1", "p2", TARGET_HOST + "/c/p1?q=1"),
+        Arguments.of("https://r/c/p1/p1?q=1", "p1", TARGET_HOST + "/c?q=1"),
+        Arguments.of("https://r/c/p1/p2?q=1", "c", TARGET_HOST + "/p1/p2?q=1"),
+        Arguments.of("https://r/c/p1/p2?q=1", "/c", TARGET_HOST + "/p1/p2?q=1"),
+        Arguments.of("https://r/c/p1/p2?q=1", "c/", TARGET_HOST + "/p1/p2?q=1"),
+        Arguments.of("https://r/c/p1/p2?q=1", "p1", TARGET_HOST + "/c/p2?q=1"),
+        Arguments.of("https://r/c/p1/p2?q=1", "p1/", TARGET_HOST + "/c/p2?q=1"),
+        Arguments.of("https://r/c/p1/p2?q=1", "/p1/", TARGET_HOST + "/c/p2?q=1"),
+        Arguments.of("https://r/c/p1/p2?q=1", "p1/p2", TARGET_HOST + "/c?q=1"),
+        Arguments.of("https://r/c/p1/p2?q=1", "p1/p2/", TARGET_HOST + "/c?q=1"),
+        Arguments.of("https://r/c/p1/p2?q=1", "/p1/p2/", TARGET_HOST + "/c?q=1"),
+        Arguments.of("https://r/c/p1/p2?q=1", "c/p1/p2/", TARGET_HOST + "/?q=1"),
+        Arguments.of("https://r/c/p1/p2?q=1", "c/p1/p2", TARGET_HOST + "/?q=1"),
+        Arguments.of("https://r/c/$hc/p1/p2?q=1", "c", TARGET_HOST + "/p1/p2?q=1"),
+        Arguments.of("https://r/c/$hc/p1/p2?q=1", "", TARGET_HOST + "/c/p1/p2?q=1"));
+  }
+}


### PR DESCRIPTION
 - The listener supports routing to targets based on configuration of rules.
 - A rule contains a `containsPath` String and the `targetHost`
 - Documentation update with samples. 