### PR TITLE
[TOAZ-242]  Makes sam action configurable, and tests fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ that have write access to a specific Sam resource.
 `listener.samInspectorProperties.samResourceType`: The type of the Sam resource to check access to.
 Defaults to `controlled-application-private-workspace-resource`, which corresponds Leo-managed resources.
 
+`listener.samInspectorProperties.samAction`: The Sam action to check. Default value is `write`
+
 ## Running Jupyter Notebooks
 
 To enable access to a Jupyter Notebooks server instance via Azure Relay using the listener,

--- a/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
@@ -37,13 +37,14 @@ public class AppConfiguration {
   @Bean
   public SamResourceClient samResourceClient(TokenChecker tokenChecker) {
     ApiClient samClient = new ApiClient();
-    samClient.setBasePath(properties.getSamInspectorProperties().samUrl());
+    samClient.setBasePath(properties.getSamInspectorProperties().getSamUrl());
     // return a simple resolver that uses the configuration value.
     return new SamResourceClient(
-        properties.getSamInspectorProperties().samResourceId(),
-        properties.getSamInspectorProperties().samResourceType(),
+        properties.getSamInspectorProperties().getSamResourceId(),
+        properties.getSamInspectorProperties().getSamResourceType(),
         samClient,
-        tokenChecker);
+        tokenChecker,
+        properties.getSamInspectorProperties().getSamAction());
   }
 
   @Bean

--- a/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
@@ -37,14 +37,14 @@ public class AppConfiguration {
   @Bean
   public SamResourceClient samResourceClient(TokenChecker tokenChecker) {
     ApiClient samClient = new ApiClient();
-    samClient.setBasePath(properties.getSamInspectorProperties().getSamUrl());
+    samClient.setBasePath(properties.getSamInspectorProperties().samUrl());
     // return a simple resolver that uses the configuration value.
     return new SamResourceClient(
-        properties.getSamInspectorProperties().getSamResourceId(),
-        properties.getSamInspectorProperties().getSamResourceType(),
+        properties.getSamInspectorProperties().samResourceId(),
+        properties.getSamInspectorProperties().samResourceType(),
         samClient,
         tokenChecker,
-        properties.getSamInspectorProperties().getSamAction());
+        properties.getSamInspectorProperties().samAction());
   }
 
   @Bean

--- a/service/src/main/java/org/broadinstitute/listener/config/SamInspectorProperties.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/SamInspectorProperties.java
@@ -1,3 +1,42 @@
 package org.broadinstitute.listener.config;
 
-public record SamInspectorProperties(String samUrl, String samResourceId, String samResourceType) {}
+public final class SamInspectorProperties {
+
+  private static final String DEFAULT_SAM_ACTION = "write";
+  private String samUrl;
+  private String samResourceId;
+  private String samResourceType;
+  private String samAction = DEFAULT_SAM_ACTION;
+
+  public String getSamUrl() {
+    return samUrl;
+  }
+
+  public String getSamResourceId() {
+    return samResourceId;
+  }
+
+  public String getSamResourceType() {
+    return samResourceType;
+  }
+
+  public String getSamAction() {
+    return samAction;
+  }
+
+  public void setSamAction(String samAction) {
+    this.samAction = samAction;
+  }
+
+  public void setSamUrl(String samUrl) {
+    this.samUrl = samUrl;
+  }
+
+  public void setSamResourceId(String samResourceId) {
+    this.samResourceId = samResourceId;
+  }
+
+  public void setSamResourceType(String samResourceType) {
+    this.samResourceType = samResourceType;
+  }
+}

--- a/service/src/main/java/org/broadinstitute/listener/config/SamInspectorProperties.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/SamInspectorProperties.java
@@ -1,42 +1,4 @@
 package org.broadinstitute.listener.config;
 
-public final class SamInspectorProperties {
-
-  private static final String DEFAULT_SAM_ACTION = "write";
-  private String samUrl;
-  private String samResourceId;
-  private String samResourceType;
-  private String samAction = DEFAULT_SAM_ACTION;
-
-  public String getSamUrl() {
-    return samUrl;
-  }
-
-  public String getSamResourceId() {
-    return samResourceId;
-  }
-
-  public String getSamResourceType() {
-    return samResourceType;
-  }
-
-  public String getSamAction() {
-    return samAction;
-  }
-
-  public void setSamAction(String samAction) {
-    this.samAction = samAction;
-  }
-
-  public void setSamUrl(String samUrl) {
-    this.samUrl = samUrl;
-  }
-
-  public void setSamResourceId(String samResourceId) {
-    this.samResourceId = samResourceId;
-  }
-
-  public void setSamResourceType(String samResourceType) {
-    this.samResourceType = samResourceType;
-  }
-}
+public record SamInspectorProperties(
+    String samUrl, String samResourceId, String samResourceType, String samAction) {}

--- a/service/src/main/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessor.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessor.java
@@ -221,6 +221,7 @@ public class RelayedHttpRequestProcessor {
 
     return result;
   }
+
   private void removeHeadersNotAcceptedByAzureRelay(Map<String, String> headers) {
     headers.remove("transfer-encoding");
     headers.remove("Transfer-Encoding");

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SamPermissionInspector.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SamPermissionInspector.java
@@ -51,7 +51,7 @@ public class SamPermissionInspector implements RequestInspector {
   }
 
   public boolean checkCachedPermission(String accessToken) {
-    var expiresAt = samResourceClient.checkWritePermission(accessToken);
+    var expiresAt = samResourceClient.checkPermission(accessToken);
     return expiresAt.isAfter(Instant.now());
   }
 

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -24,6 +24,7 @@ listener:
     samUrl:
     samResourceId:
     samResourceType: "controlled-application-private-workspace-resource"
+    samAction: "write"
   corsSupportProperties:
     preflightMethods: "OPTIONS, POST, PUT, GET, DELETE, HEAD, PATCH"
     allowHeaders: "Authorization, Content-Type, Accept, Origin,X-App-Id"

--- a/service/src/test/java/org/broadinstitute/listener/relay/http/TargetHttpResponseTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/http/TargetHttpResponseTest.java
@@ -89,7 +89,6 @@ class TargetHttpResponseTest {
               entry.getValue().stream().findFirst().get())); // multi-part headers are not supported
     }
 
-    // assertThat(targetHttpResponse.getHeaders().get().keySet(), equalTo(headers.keySet()));
     assertThat(targetHttpResponse.getContext(), equalTo(context));
   }
 }

--- a/service/src/test/java/org/broadinstitute/listener/relay/inspectors/ExpiresAtCacheTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/inspectors/ExpiresAtCacheTest.java
@@ -53,7 +53,7 @@ class ExpiresAtCacheTest {
   void setUp() {
     mock = AopTestUtils.getTargetObject(samResourceClient);
     reset(mock);
-    when(mock.checkWritePermission("accessToken")).thenReturn(Instant.ofEpochSecond(100));
+    when(mock.checkPermission("accessToken")).thenReturn(Instant.ofEpochSecond(100));
   }
 
   private Optional<Instant> getCachedExpiresAt(String accessToken) {
@@ -63,15 +63,15 @@ class ExpiresAtCacheTest {
 
   @Test
   void checkWritePermission_sucess() {
-    samResourceClient.checkWritePermission("accessToken");
+    samResourceClient.checkPermission("accessToken");
     assertThat(getCachedExpiresAt("accessToken").get(), equalTo(Instant.ofEpochSecond(100)));
     assertEquals(getCachedExpiresAt("accessToken-non-existent"), Optional.empty());
-    verify(mock, times(1)).checkWritePermission("accessToken");
+    verify(mock, times(1)).checkPermission("accessToken");
 
-    samResourceClient.checkWritePermission("accessToken");
+    samResourceClient.checkPermission("accessToken");
     verifyNoMoreInteractions(mock);
 
-    samResourceClient.checkWritePermission("accessToken2");
-    verify(mock, times(1)).checkWritePermission("accessToken2");
+    samResourceClient.checkPermission("accessToken2");
+    verify(mock, times(1)).checkPermission("accessToken2");
   }
 }

--- a/service/src/test/java/org/broadinstitute/listener/relay/inspectors/SamResourceClientTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/inspectors/SamResourceClientTest.java
@@ -30,11 +30,11 @@ class SamResourceClientTest {
   @BeforeEach
   void setUp() throws IOException, InterruptedException, ApiException {
     samResourceClient =
-        new SamResourceClient("resourceId", "resourceType", apiClient, tokenChecker);
+        new SamResourceClient("resourceId", "resourceType", apiClient, tokenChecker, "myaction");
   }
 
   @Test
-  void checkWritePermission_sucess() throws IOException, InterruptedException, ApiException {
+  void checkPermission_success() throws IOException, InterruptedException, ApiException {
     var expiresAt = Instant.now().plusSeconds(100);
     var oauthResponse = new OauthInfo(Optional.of(expiresAt), "");
     when(tokenChecker.getOauthInfo(any())).thenReturn(oauthResponse);
@@ -42,17 +42,17 @@ class SamResourceClientTest {
     when(apiClient.execute(any(), any())).thenReturn(apiResponse);
     when(apiClient.escapeString(any())).thenReturn("string");
 
-    var expiresAtAfterPermissionCheck = samResourceClient.checkWritePermission("accessToken");
+    var expiresAtAfterPermissionCheck = samResourceClient.checkPermission("accessToken");
 
     assertThat(expiresAtAfterPermissionCheck, equalTo(expiresAt));
   }
 
   @Test
-  void checkWritePermission_token_expired() throws IOException, InterruptedException {
+  void checkPermission_token_expired() throws IOException, InterruptedException {
     var oauthResponse = new OauthInfo(Optional.of(Instant.now().minusSeconds(100)), "");
     when(tokenChecker.getOauthInfo(any())).thenReturn(oauthResponse);
 
-    var res = samResourceClient.checkWritePermission("accessToken");
+    var res = samResourceClient.checkPermission("accessToken");
 
     assertThat(res, equalTo(Instant.EPOCH));
   }


### PR DESCRIPTION
 - Added the `listener.samInspectorProperties.samAction` config property, with a default value of `write`
 - Fixed tests that were not passing prior to the change. 