### PR TITLE
IA-3822 don't permission check on status calls

### DIFF
--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SamPermissionInspector.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SamPermissionInspector.java
@@ -30,7 +30,9 @@ public class SamPermissionInspector implements RequestInspector {
   @Override
   public boolean inspectRelayedHttpRequest(
       @NonNull RelayedHttpListenerRequest relayedHttpListenerRequest) {
-    return checkPermission(relayedHttpListenerRequest.getHeaders());
+    var requestPath = relayedHttpListenerRequest.getUri().toString();
+    if (requestPath.endsWith("status") || requestPath.endsWith("status/")) return true;
+    else return checkPermission(relayedHttpListenerRequest.getHeaders());
   }
 
   private boolean checkPermission(Map<String, String> headers) {


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3822

Can't add unit test easily becuz `RelayedHttpListenerRequest` is package priavte in azure SDK

Leo needs to make `status` calls to check if app or welder etc is up & running. Right now, these calls will be blocked by permission check, but we really don't need to check permission for `status` calls (maybe we need a different pattern for apps since not all apps have a `status` api...but this PR at least take care of `status`)


Will test things out