### PR TITLE
[AJ-805] File uploads block subsequent requests when using Jupyter labs 

### DIFF
--- a/service/src/main/java/org/broadinstitute/listener/relay/http/ListenerConnectionHandler.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/ListenerConnectionHandler.java
@@ -70,9 +70,10 @@ public class ListenerConnectionHandler {
                 context -> {
                   try {
                     logger.debug(
-                        "Received HTTP request. URI: {}. Tracking ID:{}",
+                        "Received HTTP request. URI: {}. Tracking ID:{} Method:{}",
                         context.getRequest().getUri(),
-                        context.getTrackingContext().getTrackingId());
+                        context.getTrackingContext().getTrackingId(),
+                        context.getRequest().getHttpMethod());
                     sink.next(context);
                   } catch (Throwable ex) {
                     logger.error(

--- a/service/src/main/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipeline.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipeline.java
@@ -87,8 +87,9 @@ public class RelayedRequestPipeline {
         .doOnDiscard(
             RelayedHttpListenerContext.class,
             httpRequestProcessor::writeNotAcceptedResponseOnCaller)
-        .flatMap((r) -> Mono.just(httpRequestProcessor.executeRequestOnTarget(r)))
-        .flatMap((r) -> Mono.just(httpRequestProcessor.writeTargetResponseOnCaller(r)))
+        .flatMap((r) -> Mono.fromCallable(() -> httpRequestProcessor.executeRequestOnTarget(r)))
+        .flatMap(
+            (r) -> Mono.fromCallable(() -> httpRequestProcessor.writeTargetResponseOnCaller(r)))
         .doOnError(ex -> logger.error("Failed to process the request.", ex))
         .subscribe(
             result -> logger.info("Processed request with the following result: {}", result));

--- a/service/src/test/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipelineTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipelineTest.java
@@ -21,6 +21,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 @ExtendWith(MockitoExtension.class)
 class RelayedRequestPipelineTest {
@@ -59,7 +60,7 @@ class RelayedRequestPipelineTest {
     when(relayedHttpRequestProcessor.writeTargetResponseOnCaller(targetHttpResponse))
         .thenReturn(Result.SUCCESS);
 
-    relayedRequestPipeline.registerHttpExecutionPipeline();
+    relayedRequestPipeline.registerHttpExecutionPipeline(Schedulers.immediate());
 
     verify(relayedHttpRequestProcessor, times(1)).executeRequestOnTarget(requestContext);
     verify(relayedHttpRequestProcessor, times(1)).writeTargetResponseOnCaller(targetHttpResponse);
@@ -76,7 +77,7 @@ class RelayedRequestPipelineTest {
         .thenReturn(false);
     when(listenerConnectionHandler.isNotPreflight(any())).thenReturn(true);
 
-    relayedRequestPipeline.registerHttpExecutionPipeline();
+    relayedRequestPipeline.registerHttpExecutionPipeline(Schedulers.immediate());
 
     verify(relayedHttpRequestProcessor, times(0)).executeRequestOnTarget(any());
     verify(relayedHttpRequestProcessor, times(0)).writeTargetResponseOnCaller(any());


### PR DESCRIPTION
 - The cause of the issue was a blocking condition encountered when the SDK flushes/closes the connection after a PUT operation. 
 - This PR configures the reactive pipeline not to use the default thread pool. 
