### PR TITLE
[IA-4125] Set accessed date via inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Each inspector may have additional configuration properties.
 By using the Sam Checker inspector, the Listener can be configured to allow access only for users
 that have write access to a specific Sam resource.
 
-#### Configuration Properties
+##### Configuration Properties
 
 `listener.samInspectorProperties.samUrl`: URL to the Sam instance we should talk to
 
@@ -76,7 +76,7 @@ The `setDateAccessed` inspector enables a callback to Leo using the auth token o
 Leo uses this call to determine if the runtime instance has been accessed recently and determine if auto-pausing is required.
 
 
-#### config options
+##### Configuration Properties
 `listener.setDateAccessedInspectorProperties.serviceHost`: Leo server host.
 `listener.setDateAccessedInspectorProperties.workspaceId`: ID of the workspace containing the runtime instance.
 `listener.setDateAccessedInspectorProperties.callWindowInSeconds`: The time window in seconds in which, at the most, one call is made to the endpoint regardless of the number of requests made during that period.

--- a/README.md
+++ b/README.md
@@ -42,10 +42,24 @@ Example configuration:
         targetHost: "http://localhost:8081"
         removeFromPath: "$hc-name/welder"
 ```
-### Sam Inspector config options
+### Inspectors
 
+Inspectors are enabled via the property `requestInspectors`.
+
+Example:
+```yaml
+requestInspectors:
+    - samChecker
+    - setDateAccessed
+```
+
+Each inspector may have additional configuration properties.
+
+#### Sam Checker Inspector
 By using the Sam Checker inspector, the Listener can be configured to allow access only for users
 that have write access to a specific Sam resource.
+
+#### Configuration Properties
 
 `listener.samInspectorProperties.samUrl`: URL to the Sam instance we should talk to
 
@@ -55,6 +69,19 @@ that have write access to a specific Sam resource.
 Defaults to `controlled-application-private-workspace-resource`, which corresponds Leo-managed resources.
 
 `listener.samInspectorProperties.samAction`: The Sam action to check. Default value is `write`
+
+#### Set Date Accessed Inspector
+
+The `setDateAccessed` inspector enables a callback to Leo using the auth token of the user.
+Leo uses this call to determine if the runtime instance has been accessed recently and determine if auto-pausing is required.
+
+
+#### config options
+`listener.setDateAccessedInspectorProperties.serviceHost`: Leo server host.
+`listener.setDateAccessedInspectorProperties.workspaceId`: ID of the workspace containing the runtime instance.
+`listener.setDateAccessedInspectorProperties.callWindowInSeconds`: The time window in seconds in which, at the most, one call is made to the endpoint regardless of the number of requests made during that period.
+`listener.setDateAccessedInspectorProperties.runtimeName` : Runtime name of the instance associated with the listener this value is part of the request to Leo.
+
 
 ## Running Jupyter Notebooks
 

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 	}
 	implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-cbcad54'
 	implementation 'com.microsoft.azure:azure-relay:0.0.5'
-	implementation 'org.apache.commons:commons-lang3:3.0'
+	implementation 'org.apache.commons:commons-lang3:3.10'
 	implementation 'io.projectreactor:reactor-core:3.4.14'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'

--- a/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
@@ -5,6 +5,8 @@ import com.microsoft.azure.relay.RelayConnectionStringBuilder;
 import com.microsoft.azure.relay.TokenProvider;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
 import java.util.ArrayList;
 import java.util.List;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
@@ -13,6 +15,7 @@ import org.broadinstitute.listener.relay.inspectors.InspectorLocator;
 import org.broadinstitute.listener.relay.inspectors.InspectorsProcessor;
 import org.broadinstitute.listener.relay.inspectors.RequestInspector;
 import org.broadinstitute.listener.relay.inspectors.SamResourceClient;
+import org.broadinstitute.listener.relay.inspectors.SetDateAccessedInspectorOptions;
 import org.broadinstitute.listener.relay.inspectors.TokenChecker;
 import org.broadinstitute.listener.relay.transport.DefaultTargetResolver;
 import org.broadinstitute.listener.relay.transport.TargetResolver;
@@ -45,6 +48,16 @@ public class AppConfiguration {
         samClient,
         tokenChecker,
         properties.getSamInspectorProperties().samAction());
+  }
+
+  @Bean
+  public SetDateAccessedInspectorOptions setDateAccessedInspectorOptions() {
+    return new SetDateAccessedInspectorOptions(
+        properties.getSetDateAccessedInspectorProperties().serviceHost(),
+        properties.getSetDateAccessedInspectorProperties().workspaceId(),
+        properties.getSetDateAccessedInspectorProperties().callWindowInSeconds(),
+        properties.getSetDateAccessedInspectorProperties().runtimeName(),
+        HttpClient.newBuilder().version(Version.HTTP_1_1).build());
   }
 
   @Bean

--- a/service/src/main/java/org/broadinstitute/listener/config/ListenerProperties.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/ListenerProperties.java
@@ -12,6 +12,7 @@ public class ListenerProperties {
   private TargetProperties targetProperties;
   private SamInspectorProperties samInspectorProperties;
   private CorsSupportProperties corsSupportProperties;
+  private SetDateAccessedInspectorProperties setDateAccessedInspectorProperties;
 
   public CorsSupportProperties getCorsSupportProperties() {
     return corsSupportProperties;
@@ -61,5 +62,14 @@ public class ListenerProperties {
 
   public void setRequestInspectors(List<InspectorType> requestInspectors) {
     this.requestInspectors = requestInspectors;
+  }
+
+  public SetDateAccessedInspectorProperties getSetDateAccessedInspectorProperties() {
+    return setDateAccessedInspectorProperties;
+  }
+
+  public void setSetDateAccessedInspectorProperties(
+      SetDateAccessedInspectorProperties setDateAccessedInspectorProperties) {
+    this.setDateAccessedInspectorProperties = setDateAccessedInspectorProperties;
   }
 }

--- a/service/src/main/java/org/broadinstitute/listener/config/SetDateAccessedInspectorProperties.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/SetDateAccessedInspectorProperties.java
@@ -1,4 +1,4 @@
 package org.broadinstitute.listener.config;
 
-public record SetDateAccessedInspectorProperties(String serviceHost, String workspaceId, int callWindowInSeconds) {
-}
+public record SetDateAccessedInspectorProperties(
+    String serviceHost, String workspaceId, int callWindowInSeconds, String runtimeName) {}

--- a/service/src/main/java/org/broadinstitute/listener/config/SetDateAccessedInspectorProperties.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/SetDateAccessedInspectorProperties.java
@@ -1,4 +1,6 @@
 package org.broadinstitute.listener.config;
 
+import java.util.UUID;
+
 public record SetDateAccessedInspectorProperties(
-    String serviceHost, String workspaceId, int callWindowInSeconds, String runtimeName) {}
+    String serviceHost, UUID workspaceId, int callWindowInSeconds, String runtimeName) {}

--- a/service/src/main/java/org/broadinstitute/listener/config/SetDateAccessedInspectorProperties.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/SetDateAccessedInspectorProperties.java
@@ -1,0 +1,4 @@
+package org.broadinstitute.listener.config;
+
+public record SetDateAccessedInspectorProperties(String serviceHost, String workspaceId, int callWindowInSeconds) {
+}

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/InspectorType.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/InspectorType.java
@@ -2,7 +2,9 @@ package org.broadinstitute.listener.relay.inspectors;
 
 public enum InspectorType {
   HEADERS_LOGGER(InspectorNameConstants.HEADERS_LOGGER),
+  SET_DATE_ACCESSED(InspectorNameConstants.SET_DATE_ACCESSED),
   SAM_CHECKER(InspectorNameConstants.SAM_CHECKER);
+
 
   private final String inspectorName;
 
@@ -17,5 +19,6 @@ public enum InspectorType {
   public interface InspectorNameConstants {
     String HEADERS_LOGGER = "headersLogger";
     String SAM_CHECKER = "samChecker";
+    String SET_DATE_ACCESSED = "setDateAccessed";
   }
 }

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/InspectorType.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/InspectorType.java
@@ -5,7 +5,6 @@ public enum InspectorType {
   SET_DATE_ACCESSED(InspectorNameConstants.SET_DATE_ACCESSED),
   SAM_CHECKER(InspectorNameConstants.SAM_CHECKER);
 
-
   private final String inspectorName;
 
   InspectorType(String inspectorName) {

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SetDateAccessedInspector.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SetDateAccessedInspector.java
@@ -102,7 +102,7 @@ public class SetDateAccessedInspector implements RequestInspector {
         updateLastAccessedDate();
       }
     } catch (RuntimeException ex) {
-      logger.error("Failed set the last accessed date. The request still will get processed", ex);
+      logger.error("Failed to set the last accessed date. The request still will get processed", ex);
     }
 
     return true;
@@ -135,7 +135,7 @@ public class SetDateAccessedInspector implements RequestInspector {
     try {
       response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
     } catch (IOException | InterruptedException e) {
-      logger.error("Failed to call the set the date accessed API", e);
+      logger.error("Failed to call the set date accessed API", e);
       throw new RuntimeException(e);
     }
 

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SetDateAccessedInspector.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SetDateAccessedInspector.java
@@ -1,0 +1,121 @@
+package org.broadinstitute.listener.relay.inspectors;
+
+import com.google.common.base.Strings;
+import com.microsoft.azure.relay.RelayedHttpListenerRequest;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Instant;
+import java.util.Locale;
+import org.apache.http.client.utils.URIBuilder;
+import org.broadinstitute.listener.relay.Utils;
+import org.broadinstitute.listener.relay.inspectors.InspectorType.InspectorNameConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component(InspectorNameConstants.SET_DATE_ACCESSED)
+public class SetDateAccessedInspector implements RequestInspector {
+  private final Logger logger = LoggerFactory.getLogger(SetDateAccessedInspector.class);
+  private Instant lastAccessedDate;
+  private final URL serviceUrl;
+
+  private final int requestWindowInSeconds;
+  private final HttpClient httpClient;
+  private static final String API_SEGMENT_PATTERN =
+      "%s/api/v2/runtimes/%s/<runtimeName>/setDateAccessed";
+
+  public SetDateAccessedInspector(
+      int requestWindowInSeconds, String serviceHost, String workspaceId, HttpClient httpClient)
+      throws URISyntaxException, MalformedURLException {
+
+    if (requestWindowInSeconds <= 0) {
+      throw new IllegalArgumentException(
+          "The request value in seconds is invalid. It must be greater than 0");
+    }
+
+    if (Strings.isNullOrEmpty(serviceHost)) {
+      throw new IllegalArgumentException(
+          "The service host is missing. Please check the configuration");
+    }
+
+    if (Strings.isNullOrEmpty(workspaceId)) {
+      throw new IllegalArgumentException(
+          "The workspace id is missing. Please check the configuration");
+    }
+
+    this.httpClient = httpClient;
+    this.requestWindowInSeconds = requestWindowInSeconds;
+
+    lastAccessedDate = Instant.now().plusSeconds(requestWindowInSeconds);
+    URIBuilder builder =
+        new URIBuilder(String.format(Locale.ROOT, API_SEGMENT_PATTERN, serviceHost, workspaceId));
+
+    serviceUrl = builder.build().toURL();
+  }
+
+  @Override
+  public boolean inspectWebSocketUpgradeRequest(
+      RelayedHttpListenerRequest relayedHttpListenerRequest) {
+
+    return checkLastAccessDateAndCallServiceIfExpired(relayedHttpListenerRequest);
+  }
+
+  @Override
+  public boolean inspectRelayedHttpRequest(RelayedHttpListenerRequest relayedHttpListenerRequest) {
+
+    return checkLastAccessDateAndCallServiceIfExpired(relayedHttpListenerRequest);
+  }
+
+  private boolean checkLastAccessDateAndCallServiceIfExpired(RelayedHttpListenerRequest relayedHttpListenerRequest) {
+    if (hasLastAccessDateExpired()){
+      setLastAccessedDateOnService(relayedHttpListenerRequest);
+      updateLastAccessedDate();
+    }
+    return true;
+  }
+
+  public void setLastAccessedDateOnService(RelayedHttpListenerRequest relayedHttpListenerRequest) {
+    HttpRequest request;
+    try {
+      request =
+          HttpRequest.newBuilder()
+              .uri(serviceUrl.toURI())
+              .method("PATCH", HttpRequest.BodyPublishers.noBody())
+              .header(
+                  "Authorization",
+                  "Bearer "
+                      + Utils.getTokenFromAuthorization(relayedHttpListenerRequest.getHeaders()))
+              .build();
+    } catch (URISyntaxException e) {
+      logger.error("Failed to parse the URL to set the date accessed via the API", e);
+      throw new RuntimeException(e);
+    }
+
+    logger.debug("Making a call to the last accessed date API at this URL: {}", serviceUrl);
+
+    HttpResponse<String> response;
+    try {
+      response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    } catch (IOException | InterruptedException e) {
+      logger.error("Failed to call the set the date accessed API", e);
+      throw new RuntimeException(e);
+    }
+
+    logger.info(
+        "The set last accessed date API call was made with the following response: {}",
+        response.statusCode());
+  }
+
+  private synchronized boolean hasLastAccessDateExpired() {
+    return Instant.now().isBefore(lastAccessedDate);
+  }
+
+  private synchronized void updateLastAccessedDate() {
+    lastAccessedDate = lastAccessedDate.plusSeconds(requestWindowInSeconds);
+  }
+}

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SetDateAccessedInspectorOptions.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SetDateAccessedInspectorOptions.java
@@ -1,0 +1,11 @@
+package org.broadinstitute.listener.relay.inspectors;
+
+import java.net.http.HttpClient;
+import java.util.UUID;
+
+public record SetDateAccessedInspectorOptions(
+    String serviceHost,
+    UUID workspaceId,
+    int callWindowInSeconds,
+    String runtimeName,
+    HttpClient httpClient) {}

--- a/service/src/main/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipeline.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipeline.java
@@ -4,6 +4,7 @@ import com.microsoft.azure.relay.HybridConnectionChannel;
 import com.microsoft.azure.relay.RelayedHttpListenerContext;
 import org.broadinstitute.listener.relay.http.ListenerConnectionHandler;
 import org.broadinstitute.listener.relay.http.RelayedHttpRequestProcessor;
+import org.broadinstitute.listener.relay.http.TargetHttpResponse;
 import org.broadinstitute.listener.relay.wss.ConnectionsPair;
 import org.broadinstitute.listener.relay.wss.WebSocketConnectionsHandler;
 import org.broadinstitute.listener.relay.wss.WebSocketConnectionsRelayerService;
@@ -82,18 +83,26 @@ public class RelayedRequestPipeline {
         .doOnDiscard(RelayedHttpListenerContext.class, httpRequestProcessor::writePreflightResponse)
         .filter(c -> listenerConnectionHandler.isNotSetCookie(c.getRequest()))
         .doOnDiscard(RelayedHttpListenerContext.class, httpRequestProcessor::writeSetCookieResponse)
-        .filter(
-            c -> listenerConnectionHandler.isRelayedHttpRequestAcceptedByInspectors(c.getRequest()))
-        .doOnDiscard(
-            RelayedHttpListenerContext.class,
-            httpRequestProcessor::writeNotAcceptedResponseOnCaller)
         .flatMap(
-            (r) ->
-                Mono.fromCallable(() -> httpRequestProcessor.executeRequestOnTarget(r))
+            (c) ->
+                Mono.fromCallable(
+                        () -> {
+                          if (listenerConnectionHandler.isRelayedHttpRequestAcceptedByInspectors(
+                              c.getRequest())) {
+                            return httpRequestProcessor.executeRequestOnTarget(c);
+                          }
+
+                          httpRequestProcessor.writeNotAcceptedResponseOnCaller(c);
+
+                          return Mono.empty();
+                        })
                     .subscribeOn(scheduler))
         .flatMap(
             (r) ->
-                Mono.fromCallable(() -> httpRequestProcessor.writeTargetResponseOnCaller(r))
+                Mono.fromCallable(
+                        () ->
+                            httpRequestProcessor.writeTargetResponseOnCaller(
+                                (TargetHttpResponse) r))
                     .subscribeOn(scheduler))
         .doOnError(ex -> logger.error("Failed to process the request.", ex))
         .subscribe(

--- a/service/src/main/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipeline.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipeline.java
@@ -91,7 +91,6 @@ public class RelayedRequestPipeline {
                               c.getRequest())) {
                             return httpRequestProcessor.executeRequestOnTarget(c);
                           }
-
                           httpRequestProcessor.writeNotAcceptedResponseOnCaller(c);
 
                           return Mono.empty();

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -18,10 +18,10 @@ listener:
         targetHost: "http://localhost:8081"
         removeFromPath: "$hc-name/welder"
   requestInspectors:
-    - headersLogger
-#    - samChecker
+#    - headersLogger
+    - samChecker
 #    - setDateAccessed
-  SetDateAccessedInspectorProperties:
+  setDateAccessedInspectorProperties:
     serviceHost:
     workspaceId:
     callWindowInSeconds: 60

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -18,8 +18,15 @@ listener:
         targetHost: "http://localhost:8081"
         removeFromPath: "$hc-name/welder"
   requestInspectors:
-#    - headersLogger
-    - samChecker
+    - headersLogger
+#    - samChecker
+#    - setDateAccessed
+  SetDateAccessedInspectorProperties:
+    serviceHost:
+    workspaceId:
+    callWindowInSeconds: 60
+    runtimeName:
+
   samInspectorProperties:
     samUrl:
     samResourceId:

--- a/service/src/test/java/org/broadinstitute/listener/relay/inspectors/SetDateAccessedInspectorTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/inspectors/SetDateAccessedInspectorTest.java
@@ -1,0 +1,107 @@
+package org.broadinstitute.listener.relay.inspectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.microsoft.azure.relay.RelayedHttpListenerRequest;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SetDateAccessedInspectorTest {
+
+  private static final int CALL_WINDOW_IN_SECONDS = 5;
+  private static final String SERVICE_HOST = "http://foo.bar";
+  public static final String AUTH_TOKEN = "Bearer AUTH_TOKEN";
+  public static final String AUTHORIZATION_HEADER = "Authorization";
+  public static final String RUNTIME_NAME = "RUNTIME_NAME";
+  @Mock private HttpClient httpClient;
+  @Mock private RelayedHttpListenerRequest listenerRequest;
+  @Mock private HttpResponse httpResponse;
+
+  @Captor private ArgumentCaptor<HttpRequest> httpRequestArgumentCaptor;
+
+  private SetDateAccessedInspectorOptions options;
+  private SetDateAccessedInspector inspector;
+  private UUID workspaceId;
+
+  private Map<String, String> headers;
+
+  @BeforeEach
+  void setUp() throws IOException, URISyntaxException, InterruptedException {
+    headers = new HashMap<>();
+    headers.put(AUTHORIZATION_HEADER, AUTH_TOKEN);
+
+    when(listenerRequest.getHeaders()).thenReturn(headers);
+
+    when(httpClient.send(any(), any())).thenReturn(httpResponse);
+
+    workspaceId = UUID.randomUUID();
+    options =
+        new SetDateAccessedInspectorOptions(
+            SERVICE_HOST, workspaceId, CALL_WINDOW_IN_SECONDS, RUNTIME_NAME, httpClient);
+    inspector = new SetDateAccessedInspector(options);
+  }
+
+  @Test
+  void inspectWebSocketUpgradeRequest_calledTwice_onlyOneCallToHttpClient()
+      throws IOException, InterruptedException {
+    inspector.inspectWebSocketUpgradeRequest(listenerRequest);
+    inspector.inspectWebSocketUpgradeRequest(listenerRequest);
+
+    verify(httpClient, times(1)).send(any(), any());
+  }
+
+  @Test
+  void inspectRelayedHttpRequest_calledTwice_onlyOneCallToHttpClient()
+      throws IOException, InterruptedException {
+    inspector.inspectWebSocketUpgradeRequest(listenerRequest);
+    inspector.inspectWebSocketUpgradeRequest(listenerRequest);
+
+    verify(httpClient, times(1)).send(any(), any());
+  }
+
+  @Test
+  void inspectRelayedHttpRequest_multipleCallsOverTwoWindows_twiceCallToHttpClient()
+      throws IOException, InterruptedException {
+    inspector.inspectWebSocketUpgradeRequest(listenerRequest);
+    inspector.inspectWebSocketUpgradeRequest(listenerRequest);
+    inspector.inspectWebSocketUpgradeRequest(listenerRequest);
+    Thread.sleep(CALL_WINDOW_IN_SECONDS * 1000);
+    inspector.inspectWebSocketUpgradeRequest(listenerRequest);
+    inspector.inspectWebSocketUpgradeRequest(listenerRequest);
+    inspector.inspectWebSocketUpgradeRequest(listenerRequest);
+
+    verify(httpClient, times(2)).send(any(), any());
+  }
+
+  @Test
+  void inspectRelayedHttpRequest_callOnce_callToLeoHasAuthHeader()
+      throws IOException, InterruptedException {
+    inspector.inspectWebSocketUpgradeRequest(listenerRequest);
+
+    verify(httpClient, times(1)).send(httpRequestArgumentCaptor.capture(), any());
+
+    assertThat(
+        httpRequestArgumentCaptor.getValue().headers().map(),
+        hasEntry(AUTHORIZATION_HEADER, List.of(AUTH_TOKEN)));
+  }
+}


### PR DESCRIPTION
This PR includes the following:
- New listener inspector `SetAccessedDateInspector` that calls Leo using the user auth token when a request is received within a window.
- At the most 1 request to Leo is made within a given window if more requests are received.
- The inspector won't block the request if the call to Leo fails. 
- Refactoring, inspectors are now executed in the same thread as the request to the local endpoint and not on the main thread. 
- Updated documentation with configuration values for the new inspector. 