### PR TITLE
[TOAZ-325] Fix ClassCastException when processing requests

### DIFF
--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SetDateAccessedInspector.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SetDateAccessedInspector.java
@@ -102,7 +102,8 @@ public class SetDateAccessedInspector implements RequestInspector {
         updateLastAccessedDate();
       }
     } catch (RuntimeException ex) {
-      logger.error("Failed to set the last accessed date. The request still will get processed", ex);
+      logger.error(
+          "Failed to set the last accessed date. The request still will get processed", ex);
     }
 
     return true;

--- a/service/src/main/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipeline.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipeline.java
@@ -4,7 +4,6 @@ import com.microsoft.azure.relay.HybridConnectionChannel;
 import com.microsoft.azure.relay.RelayedHttpListenerContext;
 import org.broadinstitute.listener.relay.http.ListenerConnectionHandler;
 import org.broadinstitute.listener.relay.http.RelayedHttpRequestProcessor;
-import org.broadinstitute.listener.relay.http.TargetHttpResponse;
 import org.broadinstitute.listener.relay.wss.ConnectionsPair;
 import org.broadinstitute.listener.relay.wss.WebSocketConnectionsHandler;
 import org.broadinstitute.listener.relay.wss.WebSocketConnectionsRelayerService;
@@ -92,16 +91,12 @@ public class RelayedRequestPipeline {
                             return httpRequestProcessor.executeRequestOnTarget(c);
                           }
                           httpRequestProcessor.writeNotAcceptedResponseOnCaller(c);
-
-                          return Mono.empty();
+                          return null;
                         })
                     .subscribeOn(scheduler))
         .flatMap(
             (r) ->
-                Mono.fromCallable(
-                        () ->
-                            httpRequestProcessor.writeTargetResponseOnCaller(
-                                (TargetHttpResponse) r))
+                Mono.fromCallable(() -> httpRequestProcessor.writeTargetResponseOnCaller(r))
                     .subscribeOn(scheduler))
         .doOnError(ex -> logger.error("Failed to process the request.", ex))
         .subscribe(

--- a/service/src/main/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipeline.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipeline.java
@@ -4,6 +4,8 @@ import com.microsoft.azure.relay.HybridConnectionChannel;
 import com.microsoft.azure.relay.RelayedHttpListenerContext;
 import org.broadinstitute.listener.relay.http.ListenerConnectionHandler;
 import org.broadinstitute.listener.relay.http.RelayedHttpRequestProcessor;
+import org.broadinstitute.listener.relay.http.RelayedHttpRequestProcessor.Result;
+import org.broadinstitute.listener.relay.http.TargetHttpResponse;
 import org.broadinstitute.listener.relay.wss.ConnectionsPair;
 import org.broadinstitute.listener.relay.wss.WebSocketConnectionsHandler;
 import org.broadinstitute.listener.relay.wss.WebSocketConnectionsRelayerService;
@@ -91,12 +93,19 @@ public class RelayedRequestPipeline {
                             return httpRequestProcessor.executeRequestOnTarget(c);
                           }
                           httpRequestProcessor.writeNotAcceptedResponseOnCaller(c);
-                          return null;
+                          return Mono.empty();
                         })
                     .subscribeOn(scheduler))
         .flatMap(
             (r) ->
-                Mono.fromCallable(() -> httpRequestProcessor.writeTargetResponseOnCaller(r))
+                Mono.fromCallable(
+                        () -> {
+                          if (r instanceof TargetHttpResponse) {
+                            return httpRequestProcessor.writeTargetResponseOnCaller(
+                                (TargetHttpResponse) r);
+                          }
+                          return Result.FAILURE;
+                        })
                     .subscribeOn(scheduler))
         .doOnError(ex -> logger.error("Failed to process the request.", ex))
         .subscribe(


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/TOAZ-325

I've noticed this error several times deploying k8s apps:
```
2023-04-21 21:11:18.634  ERROR 1 --- [oundedElastic-5] reactor.core.publisher.Operators         : Operator called default onErrorDropped

reactor.core.Exceptions$ErrorCallbackNotImplemented: java.lang.ClassCastException: class reactor.core.publisher.MonoEmpty cannot be cast to class org.broadinstitute.listener.relay.http.TargetHttpResponse (reactor.core.publisher.MonoEmpty is in unnamed module of loader 'app'; org.broadinstitute.listener.relay.http.TargetHttpResponse is in unnamed module of loader org.springframework.boot.devtools.restart.classloader.RestartClassLoader @14534429)
Caused by: java.lang.ClassCastException: class reactor.core.publisher.MonoEmpty cannot be cast to class org.broadinstitute.listener.relay.http.TargetHttpResponse (reactor.core.publisher.MonoEmpty is in unnamed module of loader 'app'; org.broadinstitute.listener.relay.http.TargetHttpResponse is in unnamed module of loader org.springframework.boot.devtools.restart.classloader.RestartClassLoader @14534429)
	at org.broadinstitute.listener.relay.transport.RelayedRequestPipeline.lambda$registerHttpExecutionPipeline$7(RelayedRequestPipeline.java:103)
	at reactor.core.publisher.MonoCallable.call(MonoCallable.java:92)
	at reactor.core.publisher.FluxSubscribeOnCallable$CallableSubscribeOnSubscription.run(FluxSubscribeOnCallable.java:227)
	at reactor.core.scheduler.SchedulerTask.call(SchedulerTask.java:68)
	at reactor.core.scheduler.SchedulerTask.call(SchedulerTask.java:28)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
```

Unfortunately the listener seems to get into a bad state after it occurs -- it can't process any subsequent requests and needs to be restarted.

I was a little unclear how to test it -- [this test](https://github.com/DataBiosphere/terra-azure-relay-listeners/blob/main/service/src/test/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipelineTest.java#L70) reproduces the error (logs the `ClassCastException`), and I confirmed it does not log the error with the fix. I wasn't sure how to add an assertion though, since the error happens in the scheduler and doesn't cause any different behavior in the mocked objects.