### PR TITLE
[IA-4082] Update access control allow origin and cookie.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+### Jira Ticket: https://broadworkbench.atlassian.net/browse/[Ticket #]
+
+<!-- ### Dependencies --->
+<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->
+
+## Summary of changes:
+<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->
+
+### What
+-
+
+### Why
+-
+
+### Testing strategy
+- [ ] <!-- Test case 1 -->
+
+<!-- ### Visual Aids -->
+<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->

--- a/service/src/main/java/org/broadinstitute/listener/config/CorsSupportProperties.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/CorsSupportProperties.java
@@ -1,4 +1,10 @@
 package org.broadinstitute.listener.config;
 
+import java.util.List;
+
 public record CorsSupportProperties(
-    String preflightMethods, String allowHeaders, String maxAge, String contentSecurityPolicy) {}
+    String preflightMethods,
+    String allowHeaders,
+    String maxAge,
+    String contentSecurityPolicy,
+    List<String> validHosts) {}

--- a/service/src/main/java/org/broadinstitute/listener/relay/Utils.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/Utils.java
@@ -1,20 +1,21 @@
 package org.broadinstitute.listener.relay;
 
-import static com.google.common.net.HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS;
-import static com.google.common.net.HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS;
-import static com.google.common.net.HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS;
-import static com.google.common.net.HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN;
-import static com.google.common.net.HttpHeaders.ACCESS_CONTROL_MAX_AGE;
-import static com.google.common.net.HttpHeaders.AUTHORIZATION;
-import static com.google.common.net.HttpHeaders.CONTENT_SECURITY_POLICY;
-
+import org.broadinstitute.listener.config.CorsSupportProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
-import org.broadinstitute.listener.config.CorsSupportProperties;
+import java.util.regex.Pattern;
+
+import static com.google.common.net.HttpHeaders.*;
 
 public class Utils {
+
+  public static final Logger logger = LoggerFactory.getLogger(Utils.class);
   public static final String TOKEN_NAME = "LeoToken";
   public static final String SET_COOKIE_API_PATH = "setcookie";
 
@@ -28,8 +29,11 @@ public class Utils {
 
   public static boolean isSetCookiePath(URI uri) {
     var splitted = uri.getPath().split("/");
-    if (splitted.length == 3) return splitted[2].toLowerCase().equals(SET_COOKIE_API_PATH);
-    else return false;
+    if (splitted.length == 3) {
+      return splitted[2].toLowerCase().equals(SET_COOKIE_API_PATH);
+    } else {
+      return false;
+    }
   }
 
   public static void writeCORSHeaders(
@@ -47,6 +51,29 @@ public class Utils {
         CONTENT_SECURITY_POLICY, corsSupportProperties.contentSecurityPolicy());
     responseHeaders.putIfAbsent(ACCESS_CONTROL_ALLOW_HEADERS, corsSupportProperties.allowHeaders());
     responseHeaders.putIfAbsent(ACCESS_CONTROL_MAX_AGE, corsSupportProperties.maxAge());
+  }
+
+  public static boolean isValidOrigin(String origin, CorsSupportProperties corsSupportProperties) {
+    String stringToCheck;
+    // We want to strip the protocol.
+    try {
+      URL url = new URL(origin);
+      stringToCheck = url.getHost();
+    } catch (MalformedURLException e) {
+      stringToCheck = origin;
+    }
+
+    logger.info(String.format("Checking origin %s", stringToCheck));
+    logger.info(corsSupportProperties.validHosts().toString());
+    // To appeal to lambda.
+    String finalStringToCheck = stringToCheck;
+    return origin.isEmpty()
+        || corsSupportProperties.validHosts().stream()
+        .anyMatch(
+            validHost ->
+                Pattern.matches(
+                    validHost.replace(".", "\\.").replace("*", ".*").replace(" ", ""),
+                    finalStringToCheck));
   }
 
   public static Optional<String> getToken(Map<String, String> headers) {

--- a/service/src/main/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessor.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessor.java
@@ -111,6 +111,12 @@ public class RelayedHttpRequestProcessor {
   }
 
   public Result writePreflightResponse(RelayedHttpListenerContext context) {
+    Map<String, String> requestHeaders = context.getRequest().getHeaders();
+    if (!Utils.isValidOrigin(requestHeaders.getOrDefault("Origin", ""), corsSupportProperties)) {
+      logger.error(String.format("Origin %s not allowed. Error Code: RHRP-001", requestHeaders.get("Origin")));
+      return Result.FAILURE;
+    }
+
     if (context.getResponse() == null) {
       logger.error("The context did not have a valid response");
       return Result.FAILURE;
@@ -140,6 +146,15 @@ public class RelayedHttpRequestProcessor {
     if (authToken.isEmpty()) return Result.FAILURE;
     else {
       try {
+        Map<String, String> requestHeaders = context.getRequest().getHeaders();
+
+        if (!Utils.isValidOrigin(
+            requestHeaders.getOrDefault("Origin", ""), corsSupportProperties)) {
+          logger.error(
+              String.format("Origin %s not allowed. Error Code: RHRP-002", requestHeaders.getOrDefault("Origin", "")));
+          return Result.FAILURE;
+        }
+
         var oauthInfo = tokenChecker.getOauthInfo(authToken.get());
 
         var now = Instant.now();
@@ -154,7 +169,7 @@ public class RelayedHttpRequestProcessor {
             .put(
                 SET_COOKIE,
                 String.format(
-                    "%s=%s; Max-Age=%s; Path=/; Secure; SameSite=None",
+                    "%s=%s; Max-Age=%s; Path=/; Secure; SameSite=None; HttpOnly",
                     Utils.TOKEN_NAME, authToken.get(), expiresIn.orElse(0L)));
 
         Utils.writeCORSHeaders(

--- a/service/src/main/java/org/broadinstitute/listener/relay/http/TargetHttpResponse.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/TargetHttpResponse.java
@@ -82,7 +82,8 @@ public class TargetHttpResponse extends HttpMessage {
   public static TargetHttpResponse createTargetHttpResponse(
       HttpResponse<?> clientHttpResponse,
       RelayedHttpListenerContext context,
-      CorsSupportProperties corsSupportProperties) {
+      CorsSupportProperties corsSupportProperties)
+      throws Exception {
     int responseStatusCode = clientHttpResponse.statusCode();
     Map<String, String> responseHeaders = new HashMap<>();
     if (clientHttpResponse.headers() != null && !clientHttpResponse.headers().map().isEmpty()) {
@@ -100,14 +101,19 @@ public class TargetHttpResponse extends HttpMessage {
                     // setcookie response from jupyter lab looks like this: set-cookie:
                     // _xsrf=2|63084c74|2d3173085f60f5a3889e8c1e1879d0a6|1654868473; expires=Sun, 10
                     // Jul 2022 13:41:13 GMT; Path=/saturn-403635c5-c58b-4bcd-b3d1-55aa5bd8919d/
-                    var cookieValue = String.format("%s; Secure; SameSite=None", headerValue);
+                    var cookieValue =
+                        String.format("%s; Secure; SameSite=None; HttpOnly", headerValue);
                     responseHeaders.put(key, cookieValue);
                   } else responseHeaders.put(key, headerValue);
                 }
               });
-
-      Utils.writeCORSHeaders(
-          responseHeaders, context.getRequest().getHeaders(), corsSupportProperties);
+      Map<String, String> requestHeaders = context.getRequest().getHeaders();
+      if (Utils.isValidOrigin(requestHeaders.getOrDefault("Origin", ""), corsSupportProperties)) {
+        Utils.writeCORSHeaders(responseHeaders, requestHeaders, corsSupportProperties);
+      } else {
+        throw new Exception(
+            String.format("Origin %s not allowed. Error Code: RHRP-003", requestHeaders.getOrDefault("Origin", "")));
+      }
     }
 
     InputStream body = (InputStream) clientHttpResponse.body();

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -37,3 +37,4 @@ listener:
     allowHeaders: "Authorization, Content-Type, Accept, Origin,X-App-Id"
     maxAge: "1728000"
     contentSecurityPolicy: "frame-ancestors http://localhost:3000;report-uri https://terra.report-uri.com/r/d/csp/reportOnly"
+    validHosts:

--- a/service/src/test/java/org/broadinstitute/listener/relay/UtilTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/UtilTest.java
@@ -5,8 +5,10 @@ import static org.hamcrest.Matchers.equalTo;
 
 import java.net.URI;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.broadinstitute.listener.config.CorsSupportProperties;
 import org.junit.jupiter.api.Test;
 
 class UtilTest {
@@ -48,5 +50,62 @@ class UtilTest {
             "https://relay-ns-995014ac-a05d-477e-9a75-1aa10bd5def5.servicebus.windows.net/saturn-4c90d242-dc9d-4d26-b858-4b7c73a97efc/setcookie");
     var res4 = Utils.isSetCookiePath(uri4);
     assertThat(res4, equalTo(true));
+  }
+
+  @Test
+  void isValidOrigin_test() {
+    // The space is intentional. The strings from azure_vm_init_script come prepended with spaces.
+    String allowedOrigin = " myorigin.com";
+
+    CorsSupportProperties mockCorsSupportProperties =
+        new CorsSupportProperties("", "", "", "", List.of(allowedOrigin));
+
+    String originToTest = "myorigin.com";
+    boolean isValidOrigin = Utils.isValidOrigin(originToTest, mockCorsSupportProperties);
+    assert (isValidOrigin);
+
+    String correctOriginWithHttps = "https://" + "myorigin.com";
+    isValidOrigin = Utils.isValidOrigin(correctOriginWithHttps, mockCorsSupportProperties);
+    assert (isValidOrigin);
+  }
+
+  @Test
+  void isValidOrigin_regex_test() {
+    String allowAllOrigin = "*";
+    CorsSupportProperties mockCorsSupportProperties =
+        new CorsSupportProperties("", "", "", "", List.of(allowAllOrigin));
+
+    String originToTest = "htttp://myorigin.csom";
+    boolean isValidOrigin = Utils.isValidOrigin(originToTest, mockCorsSupportProperties);
+    assert (isValidOrigin);
+
+    String wildCardAllowedOrigin = "*.bee.envs.terra*";
+    mockCorsSupportProperties =
+        new CorsSupportProperties("", "", "", "", List.of(wildCardAllowedOrigin));
+
+    isValidOrigin = Utils.isValidOrigin("nathan.bee.envs.terra", mockCorsSupportProperties);
+    assert (isValidOrigin);
+  }
+
+  @Test
+  void isValidOrigin_Error_test() {
+    boolean isValidOrigin;
+    String allowedOrigin = "myorigin.com";
+    CorsSupportProperties mockCorsSupportProperties =
+        new CorsSupportProperties("", "", "", "", List.of(allowedOrigin));
+
+    String invalidOrigin = "notmyorigin.com";
+
+    isValidOrigin = Utils.isValidOrigin(invalidOrigin, mockCorsSupportProperties);
+    assert (!isValidOrigin);
+
+    invalidOrigin = "myorigin.com.envs.bio";
+
+    isValidOrigin = Utils.isValidOrigin(invalidOrigin, mockCorsSupportProperties);
+    assert (!isValidOrigin);
+
+    String validOriginWithPort = "myorigin.com:3000";
+    isValidOrigin = Utils.isValidOrigin(validOriginWithPort, mockCorsSupportProperties);
+    assert !isValidOrigin;
   }
 }


### PR DESCRIPTION
<!-- Welcome to your Leonardo pull request! -->
<!-- Contributor guidelines: https://github.com/DataBiosphere/leonardo/blob/develop/CONTRIBUTING.md -->

__Jira ticket__: https://broadworkbench.atlassian.net/browse/IA-4081

Leo PR:
https://github.com/DataBiosphere/leonardo/pull/3311

<!-- ## Dependencies -->
<!-- Include any dependent tickets and describe the relationship. Include any other relevant Jira tickets. -->

## Summary of changes

<!-- Please give an abridged version of the ticket description here and/or fill out the following fields. -->

### What

- Update reference.conf to point to the image generated from the TARL PR

### Why

- Security vulnerability with request headers.

## Testing these changes

### What to test

- Inspect headers on a request with a Cookie, and confirm it ends with 'HttpOnly'<!-- Test case 1 -->
- Inspect headers on a relayed HTTP request and confirm AccessControlAllowOrigin is '*'

How to test:
Check out on your bee and deploy the Leo image for the branch `IA-4081-update-azure-relay-listeners` version hash `74fb80a9a19b` using the terra helmfile version: `0.169.101`. Details of this helmfile version can be found here: https://github.com/broadinstitute/terra-helmfile/pull/4184 
The helmfile changes remove the wildcard from the allowed hosts, which effectively ignores my Relay Listener Changes. I also included the BEE Urls for the reviewers.

Copy a CURL request to the relay listener endpoint (Such as storageLinks) and edit it to have a "bogus" origin.

The Server should deny the request.


<!-- ### Test data -->

### Who tested and where

- [ ] This change is covered by automated tests <!-- (unit, automation, contract, etc) -->
  - _NB: Rerun automation tests on this PR by commenting `jenkins retest` or `jenkins multi-test`._
- [ ] I validated this change <!-- (in what environment?) -->
- [ ] Primary reviewer validated this change <!-- (consider a pair review!) -->
- [ ] I validated this change in the dev environment <!-- (after successfully merging to `develop`) -->
