### PR TITLE
[WOR-1043] Remove cacheable annotation

### DIFF
--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/GoogleTokenInfoClient.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/GoogleTokenInfoClient.java
@@ -15,7 +15,6 @@ public class GoogleTokenInfoClient {
   private final String GOOGLE_OAUTH_SERVER =
       "https://www.googleapis.com/oauth2/v1/tokeninfo?access_token=";
 
-  @Cacheable("token_info")
   public GoogleOauthInfoResponse getTokenInfo(String token)
       throws IOException, InterruptedException {
     var request = HttpRequest.newBuilder().uri(URI.create(GOOGLE_OAUTH_SERVER + token)).build();


### PR DESCRIPTION
This [commit](https://github.com/DataBiosphere/terra-azure-relay-listeners/commit/3b326be64f0c7be9ac5155e44dd49b510ff3fa1e) introduced enhanced logging for the azure relay listener. There was also an @ cacheable  annotation errantly included [here](https://github.com/DataBiosphere/terra-azure-relay-listeners/blob/3b326be64f0c7be9ac5155e44dd49b510ff3fa1e/service/src/main/java/org/broadinstitute/listener/relay/inspectors/GoogleTokenInfoClient.java#L18). Since this cache is not configured in the spring app config, the listener fails to startup and relay requests fail. 

This annotation was errantly added during development and not needed afaict. 

Tested in a BEE:
1. Spun up WDS, imported data to a table successfully
2. Spun up a VM, turned on a Jupyter notebook and did a print("Hello world") successfully.
3. Spun up Cromwell, ran a workflow (errored out with config issues unrelated to the listener)