### PR TITLE
[IA-4283] Set dateAccessed from listener properly

### DIFF
--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SetDateAccessedInspector.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SetDateAccessedInspector.java
@@ -130,6 +130,8 @@ public class SetDateAccessedInspector implements RequestInspector {
       throw new RuntimeException(e);
     }
 
+    logger.debug("Making a call to the last accessed date API at this URL: {}", serviceUrl);
+    
     HttpResponse<String> response;
     try {
       response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SetDateAccessedInspector.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SetDateAccessedInspector.java
@@ -110,6 +110,10 @@ public class SetDateAccessedInspector implements RequestInspector {
   }
 
   public void setLastAccessedDateOnService(RelayedHttpListenerRequest relayedHttpListenerRequest) {
+    logger.info("setLastAccessedDateOnService\n\tRelayed request: "
+      .concat(relayedHttpListenerRequestToString(relayedHttpListenerRequest))
+    );
+
     HttpRequest request;
     try {
       request =
@@ -130,9 +134,7 @@ public class SetDateAccessedInspector implements RequestInspector {
       throw new RuntimeException(e);
     }
 
-    logger.info("\n\tRelayed request: "
-      .concat(relayedHttpListenerRequestToString(relayedHttpListenerRequest))
-      .concat("\n\tMaking a call to the last accessed date API at this URL: ")
+    logger.info("setLastAccessedDateOnService\n\tMaking a call to the last accessed date API at this URL: "
       .concat(serviceUrl.toString())
       .concat("\n\tRequest to Leo: ")
       .concat(httpRequestToString(request))

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SetDateAccessedInspector.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SetDateAccessedInspector.java
@@ -123,11 +123,11 @@ public class SetDateAccessedInspector implements RequestInspector {
               .header(
                   "Authorization",
                   "Bearer "
-                      + Utils.getTokenFromAuthorization(relayedHttpListenerRequest.getHeaders())
+                      + Utils.getToken(relayedHttpListenerRequest.getHeaders())
                           .orElseThrow(
                               () ->
                                   new RuntimeException(
-                                      "Authorization token not found in the request")))
+                                      "Leonardo token not found in request headers")))
               .build();
     } catch (URISyntaxException e) {
       logger.error("Failed to parse the URL to set the date accessed via the API", e);

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SetDateAccessedInspector.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SetDateAccessedInspector.java
@@ -110,10 +110,6 @@ public class SetDateAccessedInspector implements RequestInspector {
   }
 
   public void setLastAccessedDateOnService(RelayedHttpListenerRequest relayedHttpListenerRequest) {
-    logger.info("setLastAccessedDateOnService\n\tRelayed request: "
-      .concat(relayedHttpListenerRequestToString(relayedHttpListenerRequest))
-    );
-
     HttpRequest request;
     try {
       request =
@@ -134,12 +130,6 @@ public class SetDateAccessedInspector implements RequestInspector {
       throw new RuntimeException(e);
     }
 
-    logger.info("setLastAccessedDateOnService\n\tMaking a call to the last accessed date API at this URL: "
-      .concat(serviceUrl.toString())
-      .concat("\n\tRequest to Leo: ")
-      .concat(httpRequestToString(request))
-    );
-
     HttpResponse<String> response;
     try {
       response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
@@ -148,7 +138,7 @@ public class SetDateAccessedInspector implements RequestInspector {
       throw new RuntimeException(e);
     }
 
-    logger.info(
+    logger.debug(
         "The set last accessed date API call was made with the following response: {}",
         response.statusCode());
   }

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SetDateAccessedInspector.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SetDateAccessedInspector.java
@@ -123,7 +123,7 @@ public class SetDateAccessedInspector implements RequestInspector {
                           .orElseThrow(
                               () ->
                                   new RuntimeException(
-                                      "Leonardo token not found in request headers")))
+                                      "Authorization token not found in the request")))
               .build();
     } catch (URISyntaxException e) {
       logger.error("Failed to parse the URL to set the date accessed via the API", e);
@@ -138,7 +138,7 @@ public class SetDateAccessedInspector implements RequestInspector {
       throw new RuntimeException(e);
     }
 
-    logger.debug(
+    logger.info(
         "The set last accessed date API call was made with the following response: {}",
         response.statusCode());
   }
@@ -149,23 +149,5 @@ public class SetDateAccessedInspector implements RequestInspector {
 
   private synchronized void updateLastAccessedDate() {
     lastAccessedDate = lastAccessedDate.plusSeconds(callWindowInSeconds);
-  }
-
-  private String httpRequestToString(HttpRequest request) {
-    return "method: "
-      .concat(request.method())
-      .concat("\n\turi: ")
-      .concat(request.uri().toString())
-      .concat("\n\theaders: ")
-      .concat(request.headers().map().toString());
-  }
-
-  private String relayedHttpListenerRequestToString(RelayedHttpListenerRequest request) {
-    return "method: "
-      .concat(request.getHttpMethod())
-      .concat("uri: ")
-      .concat(request.getUri().toString())
-      .concat("headers: ")
-      .concat(request.getHeaders().toString());
   }
 }

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SetDateAccessedInspector.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SetDateAccessedInspector.java
@@ -27,7 +27,7 @@ public class SetDateAccessedInspector implements RequestInspector {
   private final int callWindowInSeconds;
   private final HttpClient httpClient;
   private static final int MIN_CALL_WINDOW_IN_SECONDS = 1;
-  private static final String API_ENDPOINT_PATTERN = "%s/api/v2/runtimes/%s/%s/setDateAccessed";
+  private static final String API_ENDPOINT_PATTERN = "%s/api/v2/runtimes/%s/%s/updateDateAccessed";
 
   public SetDateAccessedInspector(SetDateAccessedInspectorOptions options)
       throws URISyntaxException, MalformedURLException {

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SetDateAccessedInspector.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SetDateAccessedInspector.java
@@ -130,7 +130,13 @@ public class SetDateAccessedInspector implements RequestInspector {
       throw new RuntimeException(e);
     }
 
-    logger.debug("Making a call to the last accessed date API at this URL: {}", serviceUrl);
+    logger.info("\n\tRelayed request: "
+      .concat(relayedHttpListenerRequestToString(relayedHttpListenerRequest))
+      .concat("\n\tMaking a call to the last accessed date API at this URL: ")
+      .concat(serviceUrl.toString())
+      .concat("\n\tRequest to Leo: ")
+      .concat(httpRequestToString(request))
+    );
 
     HttpResponse<String> response;
     try {
@@ -151,5 +157,23 @@ public class SetDateAccessedInspector implements RequestInspector {
 
   private synchronized void updateLastAccessedDate() {
     lastAccessedDate = lastAccessedDate.plusSeconds(callWindowInSeconds);
+  }
+
+  private String httpRequestToString(HttpRequest request) {
+    return "method: "
+      .concat(request.method())
+      .concat("\n\turi: ")
+      .concat(request.uri().toString())
+      .concat("\n\theaders: ")
+      .concat(request.headers().map().toString());
+  }
+
+  private String relayedHttpListenerRequestToString(RelayedHttpListenerRequest request) {
+    return "method: "
+      .concat(request.getHttpMethod())
+      .concat("uri: ")
+      .concat(request.getUri().toString())
+      .concat("headers: ")
+      .concat(request.getHeaders().toString());
   }
 }


### PR DESCRIPTION
Leo PR: https://github.com/DataBiosphere/leonardo/pull/3402

Call the correct endpoint on leo (`updateDateAccessed`) and correctly parse the token from the initial request (looking in both Cookie and Authorization headers).