### PR TITLE
[IA-4395] Remove HttpOnly flag in cookie responses

### DIFF
--- a/service/src/main/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessor.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessor.java
@@ -169,7 +169,7 @@ public class RelayedHttpRequestProcessor {
             .put(
                 SET_COOKIE,
                 String.format(
-                    "%s=%s; Max-Age=%s; Path=/; Secure; SameSite=None; HttpOnly",
+                    "%s=%s; Max-Age=%s; Path=/; Secure; SameSite=None;",
                     Utils.TOKEN_NAME, authToken.get(), expiresIn.orElse(0L)));
 
         Utils.writeCORSHeaders(

--- a/service/src/main/java/org/broadinstitute/listener/relay/http/TargetHttpResponse.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/TargetHttpResponse.java
@@ -101,10 +101,10 @@ public class TargetHttpResponse extends HttpMessage {
                     // setcookie response from jupyter lab looks like this: set-cookie:
                     // _xsrf=2|63084c74|2d3173085f60f5a3889e8c1e1879d0a6|1654868473; expires=Sun, 10
                     // Jul 2022 13:41:13 GMT; Path=/saturn-403635c5-c58b-4bcd-b3d1-55aa5bd8919d/
-                    var cookieValue =
-                        String.format("%s; Secure; SameSite=None; HttpOnly", headerValue);
+                    var cookieValue = String.format("%s; Secure; SameSite=None;", headerValue);
                     responseHeaders.put(key, cookieValue);
-                  } else responseHeaders.put(key, headerValue);
+                  } else
+                    responseHeaders.put(key, headerValue);
                 }
               });
       Map<String, String> requestHeaders = context.getRequest().getHeaders();


### PR DESCRIPTION
NOTE unsafe (rolls back security compliance changes from IA-4082)

### Jira Ticket: https://broadworkbench.atlassian.net/browse/IA-4395

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
-

### Why
-

### Testing strategy
- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
