### PR TITLE
[IA-4401] Allow get status endpoints without updating dateAccessed

### DIFF
--- a/service/src/main/java/org/broadinstitute/listener/relay/http/ListenerConnectionHandler.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/ListenerConnectionHandler.java
@@ -43,9 +43,8 @@ public class ListenerConnectionHandler {
   }
 
   public boolean isNotSetCookie(RelayedHttpListenerRequest listenerRequest) {
-    var isSetCookieRequest =
-        listenerRequest.getHttpMethod().equals("GET")
-            && Utils.isSetCookiePath(listenerRequest.getUri());
+    var isSetCookieRequest = listenerRequest.getHttpMethod().equals("GET")
+        && Utils.isSetCookiePath(listenerRequest.getUri());
     return !isSetCookieRequest;
   }
 
@@ -65,23 +64,22 @@ public class ListenerConnectionHandler {
   public Flux<RelayedHttpListenerContext> receiveRelayedHttpRequests() {
 
     return Flux.create(
-        sink ->
-            listener.setRequestHandler(
-                context -> {
-                  try {
-                    logger.debug(
-                        "Received HTTP request. URI: {}. Tracking ID:{} Method:{}",
-                        context.getRequest().getUri(),
-                        context.getTrackingContext().getTrackingId(),
-                        context.getRequest().getHttpMethod());
-                    sink.next(context);
-                  } catch (Throwable ex) {
-                    logger.error(
-                        "Error while creating relayed HTTP request. Tracking ID:{}",
-                        context.getTrackingContext().getTrackingId(),
-                        ex);
-                  }
-                }));
+        sink -> listener.setRequestHandler(
+            context -> {
+              try {
+                logger.debug(
+                    "Received HTTP request. URI: {}. Tracking ID:{} Method:{}",
+                    context.getRequest().getUri(),
+                    context.getTrackingContext().getTrackingId(),
+                    context.getRequest().getHttpMethod());
+                sink.next(context);
+              } catch (Throwable ex) {
+                logger.error(
+                    "Error while creating relayed HTTP request. Tracking ID:{}",
+                    context.getTrackingContext().getTrackingId(),
+                    ex);
+              }
+            }));
   }
 
   public Mono<String> openConnection() {


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/IA-4401

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Allow api/status and welder/status endpoints to pass through the relay listener without touching dateAccessed on the runtime (which keeps the runtime from pausing).

### Why
-

### Testing strategy
- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
