### PR TITLE
AJ-1147: cache Sam responses much less aggressively

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
   application.name: terra-azure-relay-listener
   cache:
     cache-names: expiresAt
-    caffeine.spec: maximumSize=100,expireAfterWrite=600s
+    caffeine.spec: maximumSize=100,expireAfterWrite=300s
 
 listener:
   relayConnectionString:

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
   application.name: terra-azure-relay-listener
   cache:
     cache-names: expiresAt
-    caffeine.spec: maximumSize=100,expireAfterWrite=300s
+    caffeine.spec: maximumSize=100,expireAfterWrite=90s
 
 listener:
   relayConnectionString:

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
   application.name: terra-azure-relay-listener
   cache:
     cache-names: expiresAt
-    caffeine.spec: maximumSize=100,expireAfterAccess=3600s
+    caffeine.spec: maximumSize=100,expireAfterWrite=600s
 
 listener:
   relayConnectionString:


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1147

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

**_Reviewer_**: the latest version of this PR reduces the cache TTL to 90 seconds. What is your opinion of an appropriate TTL? Should we disable the cache entirely?

## Summary of changes:

Change the Sam caching eviction strategy:
* 1 hr TTL -> 90 second TTL
* expireAfterAccess -> expireAfterWrite

The expireAfterAccess -> expireAfterWrite change means that Sam responses "should be automatically removed from the cache once a fixed duration has elapsed after the entry’s creation, or the most recent replacement of its value" instead of being "automatically removed from the cache once a fixed duration has elapsed after the entry’s creation, the most recent replacement of its value, or its last read." (reference https://camel.apache.org/components/3.20.x/caffeine-cache-component.html#_component_options)

In other words, we expire Sam responses 90 seconds after the Listener receives them, instead of 1 hour after the last time the cached response was read.

### Why

With the previous Listener caching strategy, it is quite easy to hold on to a cached value long after Terra has updated the underlying permissions.


### Testing strategy
- [ ] <!-- Test case 1 -->

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
