### PR TITLE
DSEC-688 sonar static analysis

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
           distribution: 'temurin'
           cache: 'gradle'
 
-      - name: Test with coverage
+      - name: Test, coverage, and sonar
         run: ./gradlew --build-cache --scan test jacocoTestReport sonar --info
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,10 @@
 name: Build, Test and Publish
 on:
   push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,10 +44,15 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
+
       - name: Test with coverage
         run: ./gradlew --build-cache --scan test
+
       - name: Perform sonar sast
         run: ./gradlew --build-cache sonar --info
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-job:
     needs: [ build ]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,10 +46,7 @@ jobs:
           cache: 'gradle'
 
       - name: Test with coverage
-        run: ./gradlew --build-cache --scan test
-
-      - name: Perform sonar sast
-        run: ./gradlew --build-cache sonar --info
+        run: ./gradlew --build-cache --scan test jacocoTestReport sonar --info
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,8 @@ jobs:
           cache: 'gradle'
       - name: Test with coverage
         run: ./gradlew --build-cache --scan test
+      - name: Perform sonar sast
+        run: ./gradlew --build-cache sonar --info
 
   publish-job:
     needs: [ build ]

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
+
+# direnv
+.envrc

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Terra Azure Relay Listener
 
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DataBiosphere_terra-azure-relay-listeners&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DataBiosphere_terra-azure-relay-listeners)
+
 The Terra Azure Relay Listener enables secure communications with private resources deployed in a customer subscription using Azure Relay.
 
 The Terra Azure Relay Listener establishes a bi-directional channel with Azure Relay. Once the channel is established, the listener forwards HTTP requests to a private endpoint and returns the responses to the caller. The listener also supports WebSockets. The listener establishes a persistent WebSocket connection with the private resource and forwards data bidirectionally to and from the caller and private endpoint.

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ plugins {
 	// ^^ for some reason, can't use spotless in multiple subprojects without this ^^
 	id 'com.google.cloud.tools.jib' version '3.1.4' apply false
 	// ^^ see https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#i-am-seeing-method-not-found-or-class-not-found-errors-when-building
-	id "org.sonarqube" version "4.2.1.3168"
 }
 
 repositories { mavenCentral() }
@@ -21,19 +20,6 @@ subprojects {
 	dependencyManagement {
 		imports {
 			mavenBom(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES)
-		}
-	}
-}
-
-allprojects {
-	apply plugin: 'org.sonarqube'
-
-	sonar {
-		properties {
-			property "sonar.projectName", "terra-azure-relay-listeners"
-			property "sonar.projectKey", "DataBiosphere_terra-azure-relay-listeners"
-			property "sonar.organization", "broad-databiosphere"
-			property "sonar.host.url", "https://sonarcloud.io"
 		}
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
 	// ^^ for some reason, can't use spotless in multiple subprojects without this ^^
 	id 'com.google.cloud.tools.jib' version '3.1.4' apply false
 	// ^^ see https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#i-am-seeing-method-not-found-or-class-not-found-errors-when-building
+	id "org.sonarqube" version "4.2.1.3168"
 }
 
 repositories { mavenCentral() }
@@ -20,6 +21,19 @@ subprojects {
 	dependencyManagement {
 		imports {
 			mavenBom(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES)
+		}
+	}
+}
+
+allprojects {
+	apply plugin: 'org.sonarqube'
+
+	sonar {
+		properties {
+			property "sonar.projectName", "terra-azure-relay-listeners"
+			property "sonar.projectKey", "DataBiosphere_terra-azure-relay-listeners"
+			property "sonar.organization", "broad-databiosphere"
+			property "sonar.host.url", "https://sonarcloud.io"
 		}
 	}
 }

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -9,6 +9,8 @@ plugins {
 	id 'com.github.spotbugs' version '5.0.3'
 	id 'com.google.cloud.tools.jib'
 	id 'io.freefair.lombok'
+	id 'jacoco'
+	id "org.sonarqube" version "4.2.1.3168"
 }
 
 sourceCompatibility = JavaVersion.VERSION_17
@@ -45,4 +47,19 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
 	testImplementation 'org.hamcrest:hamcrest:2.2'
+}
+
+jacocoTestReport {
+	reports {
+		xml.enabled true
+	}
+}
+
+sonar {
+	properties {
+		property "sonar.projectName", "terra-azure-relay-listeners"
+		property "sonar.projectKey", "DataBiosphere_terra-azure-relay-listeners"
+		property "sonar.organization", "broad-databiosphere"
+		property "sonar.host.url", "https://sonarcloud.io"
+	}
 }


### PR DESCRIPTION
Run SonarCloud analysis, with jacoco coverage data, from gradle in the unit-tests job. Results are shown in the PR  and [on SonarCloud](https://sonarcloud.io/project/overview?id=DataBiosphere_terra-azure-relay-listeners).