### PR TITLE
AJ-1083: Add liveness and readiness checks via Spring actuator

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Push Container image
         run: |
           echo ${{ secrets.ACR_SP_PASSWORD }} | docker login ${ACR_REGISTRY} \
-          --username ${{ secrets.ACR_SP_USERNAME }} \
+          --username ${{ secrets.ACR_SP_USER }} \
           --password-stdin
 
           docker push ${{ steps.image-name.outputs.name }}

--- a/service/spring.gradle
+++ b/service/spring.gradle
@@ -8,6 +8,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation "org.springframework.boot:spring-boot-starter-cache:2.5.0"
 	implementation "com.github.ben-manes.caffeine:caffeine:3.0.2"
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 test { useJUnitPlatform() }

--- a/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
@@ -20,6 +20,7 @@ import org.broadinstitute.listener.relay.inspectors.TokenChecker;
 import org.broadinstitute.listener.relay.transport.DefaultTargetResolver;
 import org.broadinstitute.listener.relay.transport.TargetResolver;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.availability.ApplicationAvailability;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -62,9 +63,14 @@ public class AppConfiguration {
 
   @Bean
   public RelayedHttpRequestProcessor relayedHttpRequestProcessor(
-      TargetResolver targetResolver, TokenChecker tokenChecker) {
+      TargetResolver targetResolver,
+      TokenChecker tokenChecker,
+      ApplicationAvailability applicationAvailability) {
     return new RelayedHttpRequestProcessor(
-        targetResolver, properties.getCorsSupportProperties(), tokenChecker);
+        targetResolver,
+        properties.getCorsSupportProperties(),
+        tokenChecker,
+        applicationAvailability);
   }
 
   @Bean

--- a/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.listener.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.relay.HybridConnectionListener;
 import com.microsoft.azure.relay.RelayConnectionStringBuilder;
 import com.microsoft.azure.relay.TokenProvider;
@@ -20,7 +21,7 @@ import org.broadinstitute.listener.relay.inspectors.TokenChecker;
 import org.broadinstitute.listener.relay.transport.DefaultTargetResolver;
 import org.broadinstitute.listener.relay.transport.TargetResolver;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.availability.ApplicationAvailability;
+import org.springframework.boot.actuate.health.HealthEndpoint;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -65,12 +66,14 @@ public class AppConfiguration {
   public RelayedHttpRequestProcessor relayedHttpRequestProcessor(
       TargetResolver targetResolver,
       TokenChecker tokenChecker,
-      ApplicationAvailability applicationAvailability) {
+      HealthEndpoint healthEndpoint,
+      ObjectMapper objectMapper) {
     return new RelayedHttpRequestProcessor(
         targetResolver,
         properties.getCorsSupportProperties(),
         tokenChecker,
-        applicationAvailability);
+        healthEndpoint,
+        objectMapper);
   }
 
   @Bean

--- a/service/src/main/java/org/broadinstitute/listener/relay/Utils.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/Utils.java
@@ -17,6 +17,7 @@ public class Utils {
   public static final Logger logger = LoggerFactory.getLogger(Utils.class);
   public static final String TOKEN_NAME = "LeoToken";
   public static final String SET_COOKIE_API_PATH = "setcookie";
+  public static final String STATUS_API_PATH = "listenerstatus";
 
   public static final Optional<String> getTokenFromAuthorization(Map<String, String> headers) {
     var authValue = headers.getOrDefault(AUTHORIZATION, null);
@@ -84,5 +85,22 @@ public class Utils {
         .filter(s -> s.contains(String.format("%s=", Utils.TOKEN_NAME)))
         .findFirst()
         .map(s -> s.split("=")[1]);
+  }
+
+  public static boolean isStatusPath(URI uri) {
+    var splitted = uri.getPath().split("/");
+    if (splitted.length == 3) {
+      return splitted[2].toLowerCase().equals(STATUS_API_PATH);
+    } else {
+      return false;
+    }
+  }
+
+  public static final String statusResponse(boolean ok) {
+    return "{ \"ok:\": \"" + (ok ? "true" : "false") + "\" }";
+  }
+
+  public static final int statusCode(boolean ok) {
+    return ok ? 200 : 500;
   }
 }

--- a/service/src/main/java/org/broadinstitute/listener/relay/Utils.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/Utils.java
@@ -90,17 +90,9 @@ public class Utils {
   public static boolean isStatusPath(URI uri) {
     var splitted = uri.getPath().split("/");
     if (splitted.length == 3) {
-      return splitted[2].toLowerCase().equals(STATUS_API_PATH);
+      return splitted[2].equalsIgnoreCase(STATUS_API_PATH);
     } else {
       return false;
     }
-  }
-
-  public static final String statusResponse(boolean ok) {
-    return "{ \"ok:\": \"" + (ok ? "true" : "false") + "\" }";
-  }
-
-  public static final int statusCode(boolean ok) {
-    return ok ? 200 : 500;
   }
 }

--- a/service/src/main/java/org/broadinstitute/listener/relay/http/AvailabilityListener.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/AvailabilityListener.java
@@ -8,6 +8,10 @@ import org.springframework.boot.availability.ReadinessState;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
+/**
+ * Listens for availability change events from Spring Boot Actuator and writes log messages.
+ * See: https://www.baeldung.com/spring-boot-actuators
+ */
 @Component
 public class AvailabilityListener {
   private static final Logger logger = LoggerFactory.getLogger(AvailabilityListener.class);

--- a/service/src/main/java/org/broadinstitute/listener/relay/http/AvailabilityListener.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/AvailabilityListener.java
@@ -19,7 +19,7 @@ public class AvailabilityListener {
         logger.error("LivenessState: {}", event.getState());
         break;
       case CORRECT:
-        logger.debug("LivenessState: {}", event.getState());
+        logger.info("LivenessState: {}", event.getState());
         break;
       default:
         logger.error("LivenessState {} is not a known state", event.getState());
@@ -33,7 +33,7 @@ public class AvailabilityListener {
         logger.error("ReadinessState: {}", event.getState());
         break;
       case ACCEPTING_TRAFFIC:
-        logger.debug("ReadinessState: {}", event.getState());
+        logger.info("ReadinessState: {}", event.getState());
         break;
       default:
         logger.error("ReadinessState {} is not a known state", event.getState());

--- a/service/src/main/java/org/broadinstitute/listener/relay/http/AvailabilityListener.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/AvailabilityListener.java
@@ -1,0 +1,42 @@
+package org.broadinstitute.listener.relay.http;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.availability.AvailabilityChangeEvent;
+import org.springframework.boot.availability.LivenessState;
+import org.springframework.boot.availability.ReadinessState;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AvailabilityListener {
+  private static final Logger logger = LoggerFactory.getLogger(AvailabilityListener.class);
+
+  @EventListener
+  public void onLivenessEvent(AvailabilityChangeEvent<LivenessState> event) {
+    switch (event.getState()) {
+      case BROKEN:
+        logger.error("LivenessState: {}", event.getState());
+        break;
+      case CORRECT:
+        logger.debug("LivenessState: {}", event.getState());
+        break;
+      default:
+        logger.error("LivenessState {} is not a known state", event.getState());
+    }
+  }
+
+  @EventListener
+  public void onReadinessEvent(AvailabilityChangeEvent<ReadinessState> event) {
+    switch (event.getState()) {
+      case REFUSING_TRAFFIC:
+        logger.error("ReadinessState: {}", event.getState());
+        break;
+      case ACCEPTING_TRAFFIC:
+        logger.debug("ReadinessState: {}", event.getState());
+        break;
+      default:
+        logger.error("ReadinessState {} is not a known state", event.getState());
+    }
+  }
+}

--- a/service/src/main/java/org/broadinstitute/listener/relay/http/ListenerConnectionHandler.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/ListenerConnectionHandler.java
@@ -49,6 +49,13 @@ public class ListenerConnectionHandler {
     return !isSetCookieRequest;
   }
 
+  public boolean isNotStatus(RelayedHttpListenerRequest listenerRequest) {
+    var isStatusRequest =
+        listenerRequest.getHttpMethod().equals("GET")
+            && Utils.isStatusPath(listenerRequest.getUri());
+    return !isStatusRequest;
+  }
+
   public boolean isRelayedWebSocketUpgradeRequestAcceptedByInspectors(
       RelayedHttpListenerRequest listenerRequest) {
     return this.inspectorsProcessor.isRelayedWebSocketUpgradeRequestAccepted(listenerRequest);

--- a/service/src/main/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessor.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessor.java
@@ -348,7 +348,7 @@ public class RelayedHttpRequestProcessor {
   }
 
   public static OutputStream getOutputStreamFromContext(RelayedHttpListenerContext context) {
-    return (OutputStream) context.getResponse().getOutputStream();
+    return context.getResponse().getOutputStream();
   }
 
   public enum Result {

--- a/service/src/main/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessor.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessor.java
@@ -230,8 +230,8 @@ public class RelayedHttpRequestProcessor {
         listenerResponse.getHeaders(), context.getRequest().getHeaders(), corsSupportProperties);
     listenerResponse.getHeaders().put("Content-Type", "application/json");
 
-    // Use spring actuator "liveness" check to drive status endpoint
-    HealthComponent health = healthEndpoint.healthForPath("liveness");
+    // Use spring actuator health check to drive status endpoint
+    HealthComponent health = healthEndpoint.health();
 
     // Write status
     final int statusCode = health.getStatus() == Status.UP ? 200 : 500;

--- a/service/src/main/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessor.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessor.java
@@ -213,21 +213,9 @@ public class RelayedHttpRequestProcessor {
       return Result.FAILURE;
     }
 
-    // Check for valid origin
-    Map<String, String> requestHeaders = context.getRequest().getHeaders();
-    if (!Utils.isValidOrigin(requestHeaders.getOrDefault("Origin", ""), corsSupportProperties)) {
-      logger.error(
-          String.format(
-              "Origin %s not allowed. Error Code: RHRP-002",
-              requestHeaders.getOrDefault("Origin", "")));
-      return Result.FAILURE;
-    }
-
     RelayedHttpListenerResponse listenerResponse = context.getResponse();
 
     // Write headers
-    Utils.writeCORSHeaders(
-        listenerResponse.getHeaders(), context.getRequest().getHeaders(), corsSupportProperties);
     listenerResponse.getHeaders().put("Content-Type", "application/json");
 
     // Use spring actuator health check to drive status endpoint

--- a/service/src/main/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipeline.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipeline.java
@@ -84,6 +84,8 @@ public class RelayedRequestPipeline {
         .doOnDiscard(RelayedHttpListenerContext.class, httpRequestProcessor::writePreflightResponse)
         .filter(c -> listenerConnectionHandler.isNotSetCookie(c.getRequest()))
         .doOnDiscard(RelayedHttpListenerContext.class, httpRequestProcessor::writeSetCookieResponse)
+        .filter(c -> listenerConnectionHandler.isNotStatus(c.getRequest()))
+        .doOnDiscard(RelayedHttpListenerContext.class, httpRequestProcessor::writeStatusResponse)
         .flatMap(
             (c) ->
                 Mono.fromCallable(

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -38,3 +38,8 @@ listener:
     maxAge: "1728000"
     contentSecurityPolicy: "frame-ancestors http://localhost:3000;report-uri https://terra.report-uri.com/r/d/csp/reportOnly"
     validHosts:
+
+management:
+  endpoint.health.probes.enabled: true
+  health.livenessState.enabled: true
+  health.readinessState.enabled: true

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -40,6 +40,9 @@ listener:
     validHosts:
 
 management:
-  endpoint.health.probes.enabled: true
-  health.livenessState.enabled: true
-  health.readinessState.enabled: true
+  endpoints:
+    enabled-by-default: false
+    web.exposure.include: health
+  endpoint:
+    health.enabled: true
+    health.probes.enabled: true

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -39,6 +39,9 @@ listener:
     contentSecurityPolicy: "frame-ancestors http://localhost:3000;report-uri https://terra.report-uri.com/r/d/csp/reportOnly"
     validHosts:
 
+# Spring actuator config.
+# See: https://docs.spring.io/spring-boot/docs/current/actuator-api/htmlsingle/
+# For now only enable the health endpoint; and only liveness/readiness probes within the health endpoint.
 management:
   endpoints:
     enabled-by-default: false

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -44,5 +44,8 @@ management:
     enabled-by-default: false
     web.exposure.include: health
   endpoint:
-    health.enabled: true
-    health.probes.enabled: true
+    health:
+      enabled: true
+      probes.enabled: true
+  health:
+    defaults.enabled: false

--- a/service/src/test/java/org/broadinstitute/listener/relay/http/AvailabilityTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/http/AvailabilityTest.java
@@ -6,11 +6,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.actuate.health.HealthEndpoint;
 import org.springframework.boot.availability.ApplicationAvailability;
 import org.springframework.boot.availability.AvailabilityChangeEvent;
 import org.springframework.boot.availability.LivenessState;
@@ -32,8 +30,6 @@ public class AvailabilityTest {
   @Autowired private MockMvc mvc;
   @Autowired private ApplicationContext context;
   @Autowired private ApplicationAvailability applicationAvailability;
-  @Autowired private HealthEndpoint healthEndpoint;
-  @Autowired private ObjectMapper objectMapper;
 
   // Reference: https://www.baeldung.com/spring-liveness-readiness-probes
   @Test

--- a/service/src/test/java/org/broadinstitute/listener/relay/http/AvailabilityTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/http/AvailabilityTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.availability.ReadinessState;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -23,6 +24,7 @@ import org.springframework.test.web.servlet.ResultActions;
 @ExtendWith(SpringExtension.class)
 @AutoConfigureMockMvc
 @SpringBootTest({"spring.main.allow-bean-definition-overriding=true"})
+@ActiveProfiles("test")
 public class AvailabilityTest {
 
   @Autowired private MockMvc mvc;

--- a/service/src/test/java/org/broadinstitute/listener/relay/http/AvailabilityTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/http/AvailabilityTest.java
@@ -6,9 +6,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.HealthEndpoint;
 import org.springframework.boot.availability.ApplicationAvailability;
 import org.springframework.boot.availability.AvailabilityChangeEvent;
 import org.springframework.boot.availability.LivenessState;
@@ -30,6 +32,8 @@ public class AvailabilityTest {
   @Autowired private MockMvc mvc;
   @Autowired private ApplicationContext context;
   @Autowired private ApplicationAvailability applicationAvailability;
+  @Autowired private HealthEndpoint healthEndpoint;
+  @Autowired private ObjectMapper objectMapper;
 
   // Reference: https://www.baeldung.com/spring-liveness-readiness-probes
   @Test

--- a/service/src/test/java/org/broadinstitute/listener/relay/http/AvailabilityTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/http/AvailabilityTest.java
@@ -1,0 +1,72 @@
+package org.broadinstitute.listener.relay.http;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.availability.ApplicationAvailability;
+import org.springframework.boot.availability.AvailabilityChangeEvent;
+import org.springframework.boot.availability.LivenessState;
+import org.springframework.boot.availability.ReadinessState;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@ExtendWith(SpringExtension.class)
+@AutoConfigureMockMvc
+@SpringBootTest({"spring.main.allow-bean-definition-overriding=true"})
+public class AvailabilityTest {
+
+  @Autowired private MockMvc mvc;
+  @Autowired private ApplicationContext context;
+  @Autowired private ApplicationAvailability applicationAvailability;
+
+  // Reference: https://www.baeldung.com/spring-liveness-readiness-probes
+  @Test
+  public void readinessState() throws Exception {
+    assertThat(
+        "Readiness state should be ACCEPTING_TRAFFIC",
+        applicationAvailability.getReadinessState(),
+        equalTo(ReadinessState.ACCEPTING_TRAFFIC));
+    ResultActions readinessResult = mvc.perform(get("/actuator/health/readiness"));
+    readinessResult.andExpect(status().isOk()).andExpect(jsonPath("$.status").value("UP"));
+
+    AvailabilityChangeEvent.publish(context, ReadinessState.REFUSING_TRAFFIC);
+    assertThat(
+        "Readiness state should be REFUSING_TRAFFIC",
+        applicationAvailability.getReadinessState(),
+        equalTo(ReadinessState.REFUSING_TRAFFIC));
+    mvc.perform(get("/actuator/health/readiness"))
+        .andExpect(status().isServiceUnavailable())
+        .andExpect(jsonPath("$.status").value("OUT_OF_SERVICE"));
+  }
+
+  @Test
+  public void livenessState() throws Exception {
+    assertThat(
+        "Liveness state should be CORRECT",
+        applicationAvailability.getLivenessState(),
+        equalTo(LivenessState.CORRECT));
+    ResultActions result = mvc.perform(get("/actuator/health/liveness"));
+    result.andExpect(status().isOk()).andExpect(jsonPath("$.status").value("UP"));
+    ResultActions livenessResult = mvc.perform(get("/actuator/health/liveness"));
+    livenessResult.andExpect(status().isOk()).andExpect(jsonPath("$.status").value("UP"));
+
+    AvailabilityChangeEvent.publish(context, LivenessState.BROKEN);
+    assertThat(
+        "Liveness state should be BROKEN",
+        applicationAvailability.getLivenessState(),
+        equalTo(LivenessState.BROKEN));
+    mvc.perform(get("/actuator/health/liveness"))
+        .andExpect(status().isServiceUnavailable())
+        .andExpect(jsonPath("$.status").value("DOWN"));
+  }
+}

--- a/service/src/test/java/org/broadinstitute/listener/relay/http/AvailabilityTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/http/AvailabilityTest.java
@@ -25,7 +25,7 @@ import org.springframework.test.web.servlet.ResultActions;
 @AutoConfigureMockMvc
 @SpringBootTest({"spring.main.allow-bean-definition-overriding=true"})
 @ActiveProfiles("test")
-public class AvailabilityTest {
+class AvailabilityTest {
 
   @Autowired private MockMvc mvc;
   @Autowired private ApplicationContext context;
@@ -33,7 +33,7 @@ public class AvailabilityTest {
 
   // Reference: https://www.baeldung.com/spring-liveness-readiness-probes
   @Test
-  public void readinessState() throws Exception {
+  void readinessState() throws Exception {
     assertThat(
         "Readiness state should be ACCEPTING_TRAFFIC",
         applicationAvailability.getReadinessState(),
@@ -52,7 +52,7 @@ public class AvailabilityTest {
   }
 
   @Test
-  public void livenessState() throws Exception {
+  void livenessState() throws Exception {
     assertThat(
         "Liveness state should be CORRECT",
         applicationAvailability.getLivenessState(),

--- a/service/src/test/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessorTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessorTest.java
@@ -243,7 +243,7 @@ class RelayedHttpRequestProcessorTest {
     when(context.getRequest()).thenReturn(listenerRequest);
     when(listenerRequest.getHeaders()).thenReturn(requestHeaders);
     when(healthComponent.getStatus()).thenReturn(Status.UP);
-    when(healthEndpoint.healthForPath("liveness")).thenReturn(healthComponent);
+    when(healthEndpoint.health()).thenReturn(healthComponent);
     try (MockedStatic<RelayedHttpRequestProcessor> mock =
         mockStatic(RelayedHttpRequestProcessor.class)) {
       mock.when(() -> RelayedHttpRequestProcessor.getOutputStreamFromContext(any()))

--- a/service/src/test/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessorTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessorTest.java
@@ -263,7 +263,7 @@ class RelayedHttpRequestProcessorTest {
     when(context.getRequest()).thenReturn(listenerRequest);
     when(listenerRequest.getHeaders()).thenReturn(requestHeaders);
     when(healthComponent.getStatus()).thenReturn(Status.DOWN);
-    when(healthEndpoint.healthForPath("liveness")).thenReturn(healthComponent);
+    when(healthEndpoint.health()).thenReturn(healthComponent);
     try (MockedStatic<RelayedHttpRequestProcessor> mock =
         mockStatic(RelayedHttpRequestProcessor.class)) {
       mock.when(() -> RelayedHttpRequestProcessor.getOutputStreamFromContext(any()))

--- a/service/src/test/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessorTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessorTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -250,7 +249,7 @@ class RelayedHttpRequestProcessorTest {
       Result result = processor.writeStatusResponse(context);
 
       assertThat("Result is Success", result.equals(Result.SUCCESS));
-      verify(objectMapper).writeValue(eq(responseStream), eq(healthComponent));
+      verify(objectMapper).writeValue(responseStream, healthComponent);
       verify(responseStream).close();
     }
   }
@@ -268,7 +267,7 @@ class RelayedHttpRequestProcessorTest {
       Result result = processor.writeStatusResponse(context);
 
       assertThat("Result is Success", result.equals(Result.SUCCESS));
-      verify(objectMapper).writeValue(eq(responseStream), eq(healthComponent));
+      verify(objectMapper).writeValue(responseStream, healthComponent);
       verify(responseStream).close();
     }
   }

--- a/service/src/test/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessorTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessorTest.java
@@ -240,8 +240,6 @@ class RelayedHttpRequestProcessorTest {
   @Test
   void writeStatusResponse_ok() throws IOException {
     when(context.getResponse()).thenReturn(listenerResponse);
-    when(context.getRequest()).thenReturn(listenerRequest);
-    when(listenerRequest.getHeaders()).thenReturn(requestHeaders);
     when(healthComponent.getStatus()).thenReturn(Status.UP);
     when(healthEndpoint.health()).thenReturn(healthComponent);
     try (MockedStatic<RelayedHttpRequestProcessor> mock =
@@ -260,8 +258,6 @@ class RelayedHttpRequestProcessorTest {
   @Test
   void writeStatusReponse_notOk() throws IOException {
     when(context.getResponse()).thenReturn(listenerResponse);
-    when(context.getRequest()).thenReturn(listenerRequest);
-    when(listenerRequest.getHeaders()).thenReturn(requestHeaders);
     when(healthComponent.getStatus()).thenReturn(Status.DOWN);
     when(healthEndpoint.health()).thenReturn(healthComponent);
     try (MockedStatic<RelayedHttpRequestProcessor> mock =

--- a/service/src/test/java/org/broadinstitute/listener/relay/inspectors/ExpiresAtCacheTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/inspectors/ExpiresAtCacheTest.java
@@ -32,7 +32,7 @@ class ExpiresAtCacheTest {
   @Autowired private CacheManager cacheManager;
 
   private SamResourceClient mock;
-  ;
+
   @Autowired private SamResourceClient samResourceClient;
 
   @Configuration
@@ -62,7 +62,7 @@ class ExpiresAtCacheTest {
   }
 
   @Test
-  void checkWritePermission_sucess() {
+  void checkWritePermission_success() {
     samResourceClient.checkPermission("accessToken");
     assertThat(getCachedExpiresAt("accessToken").get(), equalTo(Instant.ofEpochSecond(100)));
     assertEquals(getCachedExpiresAt("accessToken-non-existent"), Optional.empty());

--- a/service/src/test/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipelineTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipelineTest.java
@@ -55,6 +55,7 @@ class RelayedRequestPipelineTest {
         .thenReturn(true);
     when(listenerConnectionHandler.isNotPreflight(any())).thenReturn(true);
     when(listenerConnectionHandler.isNotSetCookie(any())).thenReturn(true);
+    when(listenerConnectionHandler.isNotStatus(any())).thenReturn(true);
     when(relayedHttpRequestProcessor.executeRequestOnTarget(requestContext))
         .thenReturn(targetHttpResponse);
     when(relayedHttpRequestProcessor.writeTargetResponseOnCaller(targetHttpResponse))
@@ -73,6 +74,7 @@ class RelayedRequestPipelineTest {
         .thenReturn(Flux.create(s -> s.next(requestContext)));
     when(listenerConnectionHandler.isNotPreflight(any())).thenReturn(true);
     when(listenerConnectionHandler.isNotSetCookie(any())).thenReturn(true);
+    when(listenerConnectionHandler.isNotStatus(any())).thenReturn(true);
     when(listenerConnectionHandler.isRelayedHttpRequestAcceptedByInspectors(any()))
         .thenReturn(false);
     when(listenerConnectionHandler.isNotPreflight(any())).thenReturn(true);

--- a/service/src/test/resources/application-test.yml
+++ b/service/src/test/resources/application-test.yml
@@ -1,0 +1,11 @@
+listener:
+  relayConnectionString: Endpoint=sb://fake-namespace.servicebus.windows.net/;SharedAccessKeyName=listener;SharedAccessKey=fake-key;EntityPath=fake-connection
+  relayConnectionName: fake-connection
+  targetProperties:
+    targetHost: http://fake-service:8000/
+
+  setDateAccessedInspectorProperties:
+    serviceHost: https://leonardo.dsde-dev.broadinstitute.org
+    workspaceId: 5b8fa9c9-94f5-4a43-82f8-785524bd407e # fake
+    callWindowInSeconds: 60
+    runtimeName: fake-runtime


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1083

## Summary of changes:
Enable [Spring Boot Actuator](https://www.baeldung.com/spring-liveness-readiness-probes) to set up liveness and readiness probes in Spring Boot. These are configured in the Relay Listener helm chart in: https://github.com/broadinstitute/terra-helmfile/pull/4411.

The Spring Boot endpoints in the relay listener are not exposed externally. Additionally I added a `/listenerstatus` endpoint through the Relay Namespace, which also returns the actuator health endpoint payload.

### Testing strategy
Deployed via a BEE. Verified:
1. Listener pods come up, k8s events show liveness/readiness working
2. Listener logs show liveness/readiness state changes
3. `/listenerstatus` endpoint works
4. Leo metrics are populated with listener health

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
