### PR TITLE
[WM-2157] Additional check for workspace access

### DIFF
--- a/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
@@ -45,6 +45,7 @@ public class AppConfiguration {
     samClient.setBasePath(properties.getSamInspectorProperties().samUrl());
     // return a simple resolver that uses the configuration value.
     return new SamResourceClient(
+        properties.getSetDateAccessedInspectorProperties().workspaceId(),
         properties.getSamInspectorProperties().samResourceId(),
         properties.getSamInspectorProperties().samResourceType(),
         samClient,

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SamResourceClient.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SamResourceClient.java
@@ -41,6 +41,13 @@ public class SamResourceClient {
         samClient.setAccessToken(accessToken);
         var resourceApi = new ResourcesApi(samClient);
 
+        // check that user has access to workspace
+        var workspaceAccess = resourceApi.resourcePermissionV2("workspace", samResourceId, "read");
+        if (!workspaceAccess) {
+          logger.error("Unauthorized request. User doesn't have access to workspace");
+          return Instant.EPOCH;
+        }
+
         var res = resourceApi.resourcePermissionV2(samResourceType, samResourceId, samAction);
         if (res) return oauthInfo.expiresAt().get();
         else {

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SamResourceClient.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SamResourceClient.java
@@ -2,6 +2,7 @@ package org.broadinstitute.listener.relay.inspectors;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.UUID;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
@@ -10,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.cache.annotation.Cacheable;
 
 public class SamResourceClient {
+  private final UUID workspaceId;
   private final String samResourceId;
   private final String samResourceType;
   private final TokenChecker tokenChecker;
@@ -19,11 +21,13 @@ public class SamResourceClient {
   private final Logger logger = LoggerFactory.getLogger(SamResourceClient.class);
 
   public SamResourceClient(
+      UUID workspaceId,
       String samResourceId,
       String samResourceType,
       ApiClient samClient,
       TokenChecker tokenChecker,
       String samAction) {
+    this.workspaceId = workspaceId;
     this.samResourceId = samResourceId;
     this.samResourceType = samResourceType;
     this.tokenChecker = tokenChecker;
@@ -42,9 +46,10 @@ public class SamResourceClient {
         var resourceApi = new ResourcesApi(samClient);
 
         // check that user has access to workspace
-        boolean workspaceAccess = resourceApi.resourcePermissionV2("workspace", samResourceId, "read");
+        boolean workspaceAccess =
+            resourceApi.resourcePermissionV2("workspace", workspaceId.toString(), "read");
         if (!workspaceAccess) {
-          logger.error("Unauthorized request. User doesn't have access to workspace");
+          logger.error("Unauthorized request. User doesn't have access to workspace.");
           return Instant.EPOCH;
         }
 

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SamResourceClient.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SamResourceClient.java
@@ -42,7 +42,7 @@ public class SamResourceClient {
         var resourceApi = new ResourcesApi(samClient);
 
         // check that user has access to workspace
-        var workspaceAccess = resourceApi.resourcePermissionV2("workspace", samResourceId, "read");
+        boolean workspaceAccess = resourceApi.resourcePermissionV2("workspace", samResourceId, "read");
         if (!workspaceAccess) {
           logger.error("Unauthorized request. User doesn't have access to workspace");
           return Instant.EPOCH;

--- a/service/src/test/java/org/broadinstitute/listener/relay/inspectors/SamResourceClientTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/inspectors/SamResourceClientTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.ApiResponse;
@@ -30,7 +31,8 @@ class SamResourceClientTest {
   @BeforeEach
   void setUp() throws IOException, InterruptedException, ApiException {
     samResourceClient =
-        new SamResourceClient("resourceId", "resourceType", apiClient, tokenChecker, "myaction");
+        new SamResourceClient(
+            UUID.randomUUID(), "resourceId", "resourceType", apiClient, tokenChecker, "myaction");
   }
 
   @Test
@@ -59,6 +61,23 @@ class SamResourceClientTest {
 
     var res = samResourceClient.checkPermission("accessToken");
 
+    assertThat(res, equalTo(Instant.EPOCH));
+  }
+
+  @Test
+  void checkPermission_no_workspace_access()
+      throws IOException, InterruptedException, ApiException {
+    var expiresAt = Instant.now().plusSeconds(100);
+    var oauthResponse =
+        new OauthInfo(Optional.of(expiresAt), "", Map.of("email", "example@example.com"));
+    // check for workspace read access returns false
+    var apiResponse = new ApiResponse(200, Map.of(), false);
+
+    when(tokenChecker.getOauthInfo(any())).thenReturn(oauthResponse);
+    when(apiClient.execute(any(), any())).thenReturn(apiResponse);
+    when(apiClient.escapeString(any())).thenReturn("string");
+
+    var res = samResourceClient.checkPermission("accessToken");
     assertThat(res, equalTo(Instant.EPOCH));
   }
 }


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WM-2157

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Check whether a user is in the right workspace when trying to access an app or notebook

### Why
- When app owner is removed from a workspace, they lose access to their app APIs

### Testing strategy
Tested it in a BEE by updating the Relay Listener image Leo points to. Testing steps:
- User A creates a workspace and Cromwell app
- User A is able to see Cromwell app and access its APIs
- User A adds User B as owner on the workspace
- User B removes User A from the workspace
- User A can no longer access the workspace or Cromwell app APIs. Relay listener returns 403 on the request:
```
% curl -i -X 'GET' \
  'https://lz1...../cbas/api/batch/v1/methods?show_versions=false' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer <redacted>'
HTTP/1.1 403 The listener rejected the request. Tracking ID:2aa...
Via: 1.1 lz1c....9e5.servicebus.windows.net
Content-Length: 0
Server: Microsoft-HTTPAPI/2.0
Strict-Transport-Security: max-age=31536000
Date: Thu, 17 Aug 2023 20:31:10 GMT
```
Logs in Relay listener show "Unauthorized request. User doesn't have access to workspace." being logged when this request is made:
```
2023-08-17 20:31:10.458   INFO 1 --- [t@376926745-576] com.microsoft.azure.relay.RelayLogger    : HybridHttpConnection(TrackingId:2aa..., Address:https://lz1c...e5.servicebus.windows.net): request initializing.
2023-08-17 20:31:10.459   INFO 1 --- [     Thread-171] com.microsoft.azure.relay.RelayLogger    : HybridHttpConnection(TrackingId:2aa..., Address:https://lz1c...9e5.servicebus.windows.net): Request method: GET.
2023-08-17 20:31:10.459   INFO 1 --- [     Thread-171] com.microsoft.azure.relay.RelayLogger    : HybridHttpConnection(TrackingId:2aa..., Address:https://lz1c5...e5.servicebus.windows.net): Invoking user RequestHandler.
2023-08-17 20:31:10.638  ERROR 1 --- [undedElastic-59] o.b.l.r.inspectors.SamResourceClient     : Unauthorized request. User doesn't have access to workspace.
2023-08-17 20:31:10.638   INFO 1 --- [undedElastic-59] o.b.l.r.inspectors.InspectorsProcessor   : Inspection result for the HTTP request. Result: false, URI:sb://lz1c...<path-to-app>..ca34f/cbas/api/batch/v1/methods?show_versions=false
2023-08-17 20:31:10.638   INFO 1 --- [undedElastic-59] com.microsoft.azure.relay.RelayLogger    : HybridHttpConnection(TrackingId:2aa..., Address:https://lz1c5...9e5.servicebus.windows.net)+ResponseStream is closing.
2023-08-17 20:31:10.638   INFO 1 --- [undedElastic-59] com.microsoft.azure.relay.RelayLogger    : HybridHttpConnection(TrackingId:2aa..., Address:https://lz1c...9e5.servicebus.windows.net): Sending the response command on the control connection, status: 403.
2023-08-17 20:31:10.638   INFO 1 --- [undedElastic-59] com.microsoft.azure.relay.RelayLogger    : com.microsoft.azure.relay.HybridConnectionListener$ControlConnection@637c0751: Response command was sent: {"response":{"requestId":"2aa...","body":false,"statusCode":403,"statusDescription":"The listener rejected the request. Tracking ID:2aa..."}}
```

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
