### PR TITLE
IA-4489: setCookie endpoint should check user enablement and ToS

### DIFF
--- a/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
@@ -10,7 +10,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpClient.Version;
 import java.util.ArrayList;
 import java.util.List;
-import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
 import org.broadinstitute.listener.relay.http.RelayedHttpRequestProcessor;
 import org.broadinstitute.listener.relay.inspectors.InspectorLocator;
 import org.broadinstitute.listener.relay.inspectors.InspectorsProcessor;
@@ -41,13 +40,10 @@ public class AppConfiguration {
 
   @Bean
   public SamResourceClient samResourceClient(TokenChecker tokenChecker) {
-    ApiClient samClient = new ApiClient();
-    samClient.setBasePath(properties.getSamInspectorProperties().samUrl());
-    // return a simple resolver that uses the configuration value.
     return new SamResourceClient(
+        properties.getSamInspectorProperties().samUrl(),
         properties.getSamInspectorProperties().samResourceId(),
         properties.getSamInspectorProperties().samResourceType(),
-        samClient,
         tokenChecker,
         properties.getSamInspectorProperties().samAction());
   }
@@ -67,13 +63,15 @@ public class AppConfiguration {
       TargetResolver targetResolver,
       TokenChecker tokenChecker,
       HealthEndpoint healthEndpoint,
-      ObjectMapper objectMapper) {
+      ObjectMapper objectMapper,
+      SamResourceClient samResourceClient) {
     return new RelayedHttpRequestProcessor(
         targetResolver,
         properties.getCorsSupportProperties(),
         tokenChecker,
         healthEndpoint,
-        objectMapper);
+        objectMapper,
+        samResourceClient);
   }
 
   @Bean

--- a/service/src/main/java/org/broadinstitute/listener/relay/http/AvailabilityListener.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/AvailabilityListener.java
@@ -9,8 +9,8 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 /**
- * Listens for availability change events from Spring Boot Actuator and writes log messages.
- * See: https://www.baeldung.com/spring-boot-actuators
+ * Listens for availability change events from Spring Boot Actuator and writes log messages. See:
+ * https://www.baeldung.com/spring-boot-actuators
  */
 @Component
 public class AvailabilityListener {

--- a/service/src/main/java/org/broadinstitute/listener/relay/http/ListenerConnectionHandler.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/ListenerConnectionHandler.java
@@ -43,17 +43,13 @@ public class ListenerConnectionHandler {
   }
 
   public boolean isSetCookie(RelayedHttpListenerRequest listenerRequest) {
-    var isSetCookieRequest =
-        listenerRequest.getHttpMethod().equals("GET")
-            && Utils.isSetCookiePath(listenerRequest.getUri());
-    return isSetCookieRequest;
+    return listenerRequest.getHttpMethod().equals("GET")
+        && Utils.isSetCookiePath(listenerRequest.getUri());
   }
 
   public boolean isStatus(RelayedHttpListenerRequest listenerRequest) {
-    var isStatusRequest =
-        listenerRequest.getHttpMethod().equals("GET")
-            && Utils.isStatusPath(listenerRequest.getUri());
-    return isStatusRequest;
+    return listenerRequest.getHttpMethod().equals("GET")
+        && Utils.isStatusPath(listenerRequest.getUri());
   }
 
   public boolean isRelayedWebSocketUpgradeRequestAcceptedByInspectors(

--- a/service/src/main/java/org/broadinstitute/listener/relay/http/ListenerConnectionHandler.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/ListenerConnectionHandler.java
@@ -37,23 +37,23 @@ public class ListenerConnectionHandler {
     return this.inspectorsProcessor.isRelayedHttpRequestAccepted(listenerRequest);
   }
 
-  public boolean isNotPreflight(RelayedHttpListenerRequest listenerRequest) {
+  public boolean isPreflight(RelayedHttpListenerRequest listenerRequest) {
     // TODO: security enhancements, validate origin is valid
-    return !listenerRequest.getHttpMethod().equals("OPTIONS");
+    return listenerRequest.getHttpMethod().equals("OPTIONS");
   }
 
-  public boolean isNotSetCookie(RelayedHttpListenerRequest listenerRequest) {
+  public boolean isSetCookie(RelayedHttpListenerRequest listenerRequest) {
     var isSetCookieRequest =
         listenerRequest.getHttpMethod().equals("GET")
             && Utils.isSetCookiePath(listenerRequest.getUri());
-    return !isSetCookieRequest;
+    return isSetCookieRequest;
   }
 
-  public boolean isNotStatus(RelayedHttpListenerRequest listenerRequest) {
+  public boolean isStatus(RelayedHttpListenerRequest listenerRequest) {
     var isStatusRequest =
         listenerRequest.getHttpMethod().equals("GET")
             && Utils.isStatusPath(listenerRequest.getUri());
-    return !isStatusRequest;
+    return isStatusRequest;
   }
 
   public boolean isRelayedWebSocketUpgradeRequestAcceptedByInspectors(

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SamResourceClient.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SamResourceClient.java
@@ -1,34 +1,39 @@
 package org.broadinstitute.listener.relay.inspectors;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.time.Instant;
+import okhttp3.OkHttpClient;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
+import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cache.annotation.Cacheable;
 
 public class SamResourceClient {
+  private final String samUrl;
   private final String samResourceId;
   private final String samResourceType;
   private final TokenChecker tokenChecker;
-  private final ApiClient samClient;
   private final String samAction;
+  private final OkHttpClient commonHttpClient;
 
   private final Logger logger = LoggerFactory.getLogger(SamResourceClient.class);
 
   public SamResourceClient(
+      String samUrl,
       String samResourceId,
       String samResourceType,
-      ApiClient samClient,
       TokenChecker tokenChecker,
       String samAction) {
+    this.samUrl = samUrl;
     this.samResourceId = samResourceId;
     this.samResourceType = samResourceType;
     this.tokenChecker = tokenChecker;
-    this.samClient = samClient;
     this.samAction = samAction;
+    this.commonHttpClient = new ApiClient().getHttpClient().newBuilder().build();
   }
 
   // Should only be used in checkCachedPermission, but making it public so that we can test it
@@ -38,8 +43,8 @@ public class SamResourceClient {
       var oauthInfo = tokenChecker.getOauthInfo(accessToken);
       if (oauthInfo.expiresAt().isPresent()) {
 
-        samClient.setAccessToken(accessToken);
-        var resourceApi = new ResourcesApi(samClient);
+        var apiClient = getApiClient(accessToken);
+        var resourceApi = new ResourcesApi(apiClient);
 
         var res = resourceApi.resourcePermissionV2(samResourceType, samResourceId, samAction);
         if (res) return oauthInfo.expiresAt().get();
@@ -61,5 +66,36 @@ public class SamResourceClient {
       logger.error("Fail for unknown reasons", e);
       return Instant.EPOCH;
     }
+  }
+
+  /**
+   * Checks if the given user is enabled in Sam and has accepted the Terms of Service.
+   *
+   * @param accessToken user token
+   * @return true if the user is enabled; false otherwise.
+   */
+  public boolean isUserEnabled(String accessToken) {
+    var apiClient = getApiClient(accessToken);
+    var usersApi = new UsersApi(apiClient);
+    try {
+      var userInfo = usersApi.getUserStatusInfo();
+      // Note getEnabled() also includes whether the user has accepted the Terms of Service
+      return userInfo.getEnabled();
+    } catch (ApiException e) {
+      logger.error("Fail to check Sam permission", e);
+      return false;
+    } catch (Exception e) {
+      logger.error("Fail for unknown reasons", e);
+      return false;
+    }
+  }
+
+  @VisibleForTesting
+  ApiClient getApiClient(String accessToken) {
+    // OkHttpClient objects manage their own thread pools, so it's much more performant to share one
+    // across requests.
+    ApiClient apiClient = new ApiClient().setHttpClient(commonHttpClient).setBasePath(samUrl);
+    apiClient.setAccessToken(accessToken);
+    return apiClient;
   }
 }

--- a/service/src/test/java/org/broadinstitute/listener/relay/inspectors/SamResourceClientTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/inspectors/SamResourceClientTest.java
@@ -2,7 +2,13 @@ package org.broadinstitute.listener.relay.inspectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -12,25 +18,28 @@ import java.util.Optional;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.ApiResponse;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
 import org.broadinstitute.listener.relay.OauthInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class SamResourceClientTest {
 
-  private SamResourceClient samResourceClient;
-
-  @Mock private TokenChecker tokenChecker;
+  private TokenChecker tokenChecker = mock(TokenChecker.class);
   @Mock private ApiClient apiClient;
+
+  @Spy
+  private SamResourceClient samResourceClient =
+      new SamResourceClient("samUrl", "resourceId", "resourceType", tokenChecker, "myaction");
 
   @BeforeEach
   void setUp() throws IOException, InterruptedException, ApiException {
-    samResourceClient =
-        new SamResourceClient("resourceId", "resourceType", apiClient, tokenChecker, "myaction");
+    doReturn(apiClient).when(samResourceClient).getApiClient(anyString());
   }
 
   @Test
@@ -60,5 +69,28 @@ class SamResourceClientTest {
     var res = samResourceClient.checkPermission("accessToken");
 
     assertThat(res, equalTo(Instant.EPOCH));
+  }
+
+  @Test
+  void isUserEnabled_enabled() throws ApiException {
+    var apiResponse = new ApiResponse(200, Map.of(), new UserStatusInfo().enabled(true));
+    when(apiClient.execute(any(), any())).thenReturn(apiResponse);
+    var res = samResourceClient.isUserEnabled("token");
+    assertTrue(res);
+  }
+
+  @Test
+  void isUserEnabled_disabled() throws ApiException {
+    var apiResponse = new ApiResponse(200, Map.of(), new UserStatusInfo().enabled(false));
+    when(apiClient.execute(any(), any())).thenReturn(apiResponse);
+    var res = samResourceClient.isUserEnabled("token");
+    assertFalse(res);
+  }
+
+  @Test
+  void isUserEnabled_error() throws ApiException {
+    doThrow(new ApiException()).when(apiClient).execute(any(), any());
+    var res = samResourceClient.isUserEnabled("token");
+    assertFalse(res);
   }
 }

--- a/service/src/test/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipelineTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipelineTest.java
@@ -53,9 +53,9 @@ class RelayedRequestPipelineTest {
         .thenReturn(Flux.create(s -> s.next(requestContext)));
     when(listenerConnectionHandler.isRelayedHttpRequestAcceptedByInspectors(any()))
         .thenReturn(true);
-    when(listenerConnectionHandler.isNotPreflight(any())).thenReturn(true);
-    when(listenerConnectionHandler.isNotSetCookie(any())).thenReturn(true);
-    when(listenerConnectionHandler.isNotStatus(any())).thenReturn(true);
+    when(listenerConnectionHandler.isPreflight(any())).thenReturn(false);
+    when(listenerConnectionHandler.isSetCookie(any())).thenReturn(false);
+    when(listenerConnectionHandler.isStatus(any())).thenReturn(false);
     when(relayedHttpRequestProcessor.executeRequestOnTarget(requestContext))
         .thenReturn(targetHttpResponse);
     when(relayedHttpRequestProcessor.writeTargetResponseOnCaller(targetHttpResponse))
@@ -72,12 +72,11 @@ class RelayedRequestPipelineTest {
   void registerHttpExecutionPipeline_isNotAcceptedByInspector() {
     when(listenerConnectionHandler.receiveRelayedHttpRequests())
         .thenReturn(Flux.create(s -> s.next(requestContext)));
-    when(listenerConnectionHandler.isNotPreflight(any())).thenReturn(true);
-    when(listenerConnectionHandler.isNotSetCookie(any())).thenReturn(true);
-    when(listenerConnectionHandler.isNotStatus(any())).thenReturn(true);
+    when(listenerConnectionHandler.isPreflight(any())).thenReturn(false);
+    when(listenerConnectionHandler.isSetCookie(any())).thenReturn(false);
+    when(listenerConnectionHandler.isStatus(any())).thenReturn(false);
     when(listenerConnectionHandler.isRelayedHttpRequestAcceptedByInspectors(any()))
         .thenReturn(false);
-    when(listenerConnectionHandler.isNotPreflight(any())).thenReturn(true);
 
     relayedRequestPipeline.registerHttpExecutionPipeline(Schedulers.immediate());
 


### PR DESCRIPTION
JIRA: https://broadworkbench.atlassian.net/browse/IA-4489

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
<!--Please give an abridged version of the ticket description here and/or fill out the following fields.-->

### What
- Add `SamResourceClient.isUserEnabled` method and call it from the `setCookie` endpoint
- Added unit test coverage for `setCookie`
- Improvements to `SamResourceClient` -- instantiate a new client for each request but use shared thread pool

### Why
- During security review, determined that `setCookie` was not validating Terra user enablement/ToS. We previously fixed a similar issue in the Leo-proxy implementation of `setCookie`.

### Testing strategy
- ✅  Unit test coverage of setCookie for enabled/disabled users
- (TODO) test on a BEE 

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
