### PR TITLE
AJ-1550: logging and health check for HybridConnectionListener

### DIFF
--- a/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
@@ -19,7 +19,6 @@ import org.broadinstitute.listener.relay.inspectors.SetDateAccessedInspectorOpti
 import org.broadinstitute.listener.relay.inspectors.TokenChecker;
 import org.broadinstitute.listener.relay.transport.DefaultTargetResolver;
 import org.broadinstitute.listener.relay.transport.TargetResolver;
-import org.broadinstitute.listener.relay.wss.WebSocketConnectionsRelayerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -86,16 +85,15 @@ public class AppConfiguration {
     TokenProvider tokenProvider =
         TokenProvider.createSharedAccessSignatureTokenProvider(
             connectionParams.getSharedAccessKeyName(), connectionParams.getSharedAccessKey());
-    HybridConnectionListener hybridConnectionListener = new HybridConnectionListener(
-        new URI(connectionParams.getEndpoint().toString() + connectionParams.getEntityPath()),
-        tokenProvider);
+    HybridConnectionListener hybridConnectionListener =
+        new HybridConnectionListener(
+            new URI(connectionParams.getEndpoint().toString() + connectionParams.getEntityPath()),
+            tokenProvider);
 
-    hybridConnectionListener.setOfflineHandler(t ->
-      logger.warn("HybridConnectionListener is now offline")
-    );
-    hybridConnectionListener.setOnlineHandler(() ->
-        logger.warn("HybridConnectionListener is now online")
-    );
+    hybridConnectionListener.setOfflineHandler(
+        t -> logger.warn("HybridConnectionListener is now offline"));
+    hybridConnectionListener.setOnlineHandler(
+        () -> logger.warn("HybridConnectionListener is now online"));
 
     return hybridConnectionListener;
   }

--- a/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
@@ -19,6 +19,9 @@ import org.broadinstitute.listener.relay.inspectors.SetDateAccessedInspectorOpti
 import org.broadinstitute.listener.relay.inspectors.TokenChecker;
 import org.broadinstitute.listener.relay.transport.DefaultTargetResolver;
 import org.broadinstitute.listener.relay.transport.TargetResolver;
+import org.broadinstitute.listener.relay.wss.WebSocketConnectionsRelayerService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.HealthEndpoint;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -77,14 +80,24 @@ public class AppConfiguration {
 
   @Bean
   public HybridConnectionListener listener() throws URISyntaxException {
+    Logger logger = LoggerFactory.getLogger(HybridConnectionListener.class);
     RelayConnectionStringBuilder connectionParams =
         new RelayConnectionStringBuilder(properties.getRelayConnectionString());
     TokenProvider tokenProvider =
         TokenProvider.createSharedAccessSignatureTokenProvider(
             connectionParams.getSharedAccessKeyName(), connectionParams.getSharedAccessKey());
-    return new HybridConnectionListener(
+    HybridConnectionListener hybridConnectionListener = new HybridConnectionListener(
         new URI(connectionParams.getEndpoint().toString() + connectionParams.getEntityPath()),
         tokenProvider);
+
+    hybridConnectionListener.setOfflineHandler(t ->
+      logger.warn("HybridConnectionListener is now offline")
+    );
+    hybridConnectionListener.setOnlineHandler(() ->
+        logger.warn("HybridConnectionListener is now online")
+    );
+
+    return hybridConnectionListener;
   }
 
   @Bean

--- a/service/src/main/java/org/broadinstitute/listener/relay/health/HybridConnectionListenerHealth.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/health/HybridConnectionListenerHealth.java
@@ -6,9 +6,8 @@ import org.springframework.boot.actuate.health.Health.Builder;
 import org.springframework.stereotype.Component;
 
 /**
- * Contributes to Actuator health reporting. This health check
- * signals if the HybridConnectionListener used by this listener
- * is currently online.
+ * Contributes to Actuator health reporting. This health check signals if the
+ * HybridConnectionListener used by this listener is currently online.
  */
 @Component
 public class HybridConnectionListenerHealth extends AbstractHealthIndicator {

--- a/service/src/main/java/org/broadinstitute/listener/relay/health/HybridConnectionListenerHealth.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/health/HybridConnectionListenerHealth.java
@@ -1,0 +1,34 @@
+package org.broadinstitute.listener.relay.health;
+
+import com.microsoft.azure.relay.HybridConnectionListener;
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health.Builder;
+import org.springframework.stereotype.Component;
+
+/**
+ * Contributes to Actuator health reporting. This health check
+ * signals if the HybridConnectionListener used by this listener
+ * is currently online.
+ */
+@Component
+public class HybridConnectionListenerHealth extends AbstractHealthIndicator {
+
+  private final HybridConnectionListener listener;
+
+  public HybridConnectionListenerHealth(HybridConnectionListener listener) {
+    this.listener = listener;
+  }
+
+  @Override
+  protected void doHealthCheck(Builder builder) throws Exception {
+    try {
+      if (listener.isOnline()) {
+        builder.up();
+      } else {
+        builder.down().withDetail("reason", "HybridConnectionListener is offline");
+      }
+    } catch (Throwable ex) {
+      builder.down(ex);
+    }
+  }
+}

--- a/service/src/main/java/org/broadinstitute/listener/relay/health/HybridConnectionListenerHealth.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/health/HybridConnectionListenerHealth.java
@@ -26,7 +26,7 @@ public class HybridConnectionListenerHealth extends AbstractHealthIndicator {
       } else {
         builder.down().withDetail("reason", "HybridConnectionListener is offline");
       }
-    } catch (Throwable ex) {
+    } catch (Exception ex) {
       builder.down(ex);
     }
   }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -98,5 +98,8 @@ management:
     health:
       enabled: true
       probes.enabled: true
+      group:
+        liveness:
+          include: livenessState,hybridConnectionListenerHealth
   health:
     defaults.enabled: false

--- a/service/src/test/java/org/broadinstitute/listener/relay/http/AvailabilityTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/http/AvailabilityTest.java
@@ -2,19 +2,27 @@ package org.broadinstitute.listener.relay.http;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.microsoft.azure.relay.HybridConnectionListener;
+import org.broadinstitute.listener.relay.health.HybridConnectionListenerHealth;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
 import org.springframework.boot.availability.ApplicationAvailability;
 import org.springframework.boot.availability.AvailabilityChangeEvent;
 import org.springframework.boot.availability.LivenessState;
 import org.springframework.boot.availability.ReadinessState;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -30,6 +38,14 @@ class AvailabilityTest {
   @Autowired private MockMvc mvc;
   @Autowired private ApplicationContext context;
   @Autowired private ApplicationAvailability applicationAvailability;
+  @Autowired private HybridConnectionListenerHealth hybridConnectionListenerHealth;
+
+  @MockBean private HybridConnectionListener hybridConnectionListener;
+
+  @BeforeEach
+  void beforeEach() {
+    when(hybridConnectionListener.isOnline()).thenReturn(true);
+  }
 
   // Reference: https://www.baeldung.com/spring-liveness-readiness-probes
   @Test
@@ -70,5 +86,45 @@ class AvailabilityTest {
     mvc.perform(get("/actuator/health/liveness"))
         .andExpect(status().isServiceUnavailable())
         .andExpect(jsonPath("$.status").value("DOWN"));
+  }
+
+  /**
+   * Verify that the HybridConnectionListenerHealth custom health check contributes to the UP/DOWN
+   * status of this app's liveness probe.
+   *
+   * @throws Exception on exception in the test
+   */
+  @Test
+  void hybridConnectionListenerHealth() throws Exception {
+    // livenessState and liveness probe should both be ok, to start
+    assertThat(
+        "Liveness state should be CORRECT",
+        applicationAvailability.getLivenessState(),
+        equalTo(LivenessState.CORRECT));
+    ResultActions result = mvc.perform(get("/actuator/health/liveness"));
+    result.andExpect(status().isOk()).andExpect(jsonPath("$.status").value("UP"));
+    ResultActions livenessResult = mvc.perform(get("/actuator/health/liveness"));
+    livenessResult.andExpect(status().isOk()).andExpect(jsonPath("$.status").value("UP"));
+
+    // set the (mock) hybridConnectionListener to be offline
+    when(hybridConnectionListener.isOnline()).thenReturn(false);
+    // trigger a health check
+    Health actualHealth = hybridConnectionListenerHealth.health();
+
+    // health check should be DOWN since hybridConnectionListener is offline
+    assertEquals(Status.DOWN, actualHealth.getStatus());
+
+    // liveness probe overall status should be DOWN since hybridConnectionListener is offline
+    mvc.perform(get("/actuator/health/liveness"))
+        .andExpect(status().isServiceUnavailable())
+        .andExpect(jsonPath("$.status").value("DOWN"));
+
+    // livenessState should remain CORRECT. The HybridConnectionListenerHealth check affects
+    // the liveness probe, but not the liveness state.
+    // in other words, livenessProbe = livenessState && hybridConnectionListenerHealth.
+    assertThat(
+        "Liveness state should be CORRECT",
+        applicationAvailability.getLivenessState(),
+        equalTo(LivenessState.CORRECT));
   }
 }


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1550

## Summary of changes:
Adds a new `hybridConnectionListenerHealth` health check, via Actuator, to the k8s liveness probe. This health check echoes the state of `HybridConnectionListener.isOnline()`, which is part of the `azure-relay` library.

### Why
It seems that if the listener runs into certain errors - specifically, we've seen problems with `java.util.concurrent.TimeoutException: DNS timeout 15000 ms` - the listener's connections hang and stop responding.

This PR adds the listener's online state to the actuator health check. In theory, this would allow k8s to kill the listener pod and restart a new pod. This is drastic, but it could kick the listener connection back to a good place.

-

### Testing strategy
- [x] Added a unit test that verifies `HybridConnectionListener.isOnline()` affects the liveness probe
- [ ] Needs manual testing, in a real AKS environment, to see if `HybridConnectionListener.isOnline()` is reliable and goes down in the use cases we are seeing. See [this comment](https://github.com/DataBiosphere/terra-azure-relay-listeners/pull/56#pullrequestreview-1836825305)

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
