### PR TITLE
AJ-1550: handle errors during startup

### DIFF
--- a/service/src/main/java/org/broadinstitute/listener/StartupHandler.java
+++ b/service/src/main/java/org/broadinstitute/listener/StartupHandler.java
@@ -1,7 +1,13 @@
 package org.broadinstitute.listener;
 
+import org.broadinstitute.listener.relay.ListenerException;
 import org.broadinstitute.listener.relay.transport.RelayedRequestPipeline;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.availability.AvailabilityChangeEvent;
+import org.springframework.boot.availability.LivenessState;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -9,13 +15,25 @@ import org.springframework.stereotype.Component;
 public class StartupHandler {
 
   private final RelayedRequestPipeline relayedRequestPipeline;
+  private final ApplicationContext context;
 
-  public StartupHandler(RelayedRequestPipeline relayedRequestPipeline) {
+  private static final Logger logger = LoggerFactory.getLogger(StartupHandler.class);
+
+  public StartupHandler(RelayedRequestPipeline relayedRequestPipeline, ApplicationContext context) {
     this.relayedRequestPipeline = relayedRequestPipeline;
+    this.context = context;
   }
 
   @EventListener(ApplicationReadyEvent.class)
-  public void startProcessingRequests() {
-    this.relayedRequestPipeline.processRelayedRequests();
+  public void startProcessingRequests() throws ListenerException {
+    logger.info("Starting pipeline to process relayed requests ... ");
+    try {
+      this.relayedRequestPipeline.processRelayedRequests();
+      logger.info("Relayed requests pipeline started.");
+    } catch (Throwable t) {
+      logger.error("Error starting relayed requests pipeline: {}", t.getMessage());
+      AvailabilityChangeEvent.publish(context, LivenessState.BROKEN);
+      throw new ListenerException("Error during listener startup: " + t.getMessage(), t);
+    }
   }
 }

--- a/service/src/main/java/org/broadinstitute/listener/StartupHandler.java
+++ b/service/src/main/java/org/broadinstitute/listener/StartupHandler.java
@@ -25,13 +25,13 @@ public class StartupHandler {
   }
 
   @EventListener(ApplicationReadyEvent.class)
+  @SuppressWarnings("java:S1181") // intentionally catches Throwable, not Exception
   public void startProcessingRequests() throws ListenerException {
     logger.info("Starting pipeline to process relayed requests ... ");
     try {
       this.relayedRequestPipeline.processRelayedRequests();
       logger.info("Relayed requests pipeline started.");
     } catch (Throwable t) {
-      logger.error("Error starting relayed requests pipeline: {}", t.getMessage());
       AvailabilityChangeEvent.publish(context, LivenessState.BROKEN);
       throw new ListenerException("Error during listener startup: " + t.getMessage(), t);
     }

--- a/service/src/main/java/org/broadinstitute/listener/relay/ListenerException.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/ListenerException.java
@@ -1,0 +1,12 @@
+package org.broadinstitute.listener.relay;
+
+public class ListenerException extends Exception {
+
+  public ListenerException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public ListenerException(String message) {
+    super(message);
+  }
+}

--- a/service/src/main/java/org/broadinstitute/listener/relay/http/ListenerConnectionHandler.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/ListenerConnectionHandler.java
@@ -90,7 +90,7 @@ public class ListenerConnectionHandler {
   public Mono<String> openConnection() {
     return Mono.create(
         sink -> {
-          logger.debug("Opening connection to Azure Relay.");
+          logger.info("Opening connection to Azure Relay.");
           listener
               .openAsync()
               .whenComplete(

--- a/service/src/main/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipeline.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/transport/RelayedRequestPipeline.java
@@ -41,10 +41,10 @@ public class RelayedRequestPipeline {
   }
 
   public void processRelayedRequests() {
-    logger.debug("Registering HTTP pipeline");
+    logger.info("Registering HTTP pipeline");
     registerHttpExecutionPipeline(Schedulers.boundedElastic());
 
-    logger.debug("Registering WebSocket upgrades pipeline");
+    logger.info("Registering WebSocket upgrades pipeline");
     webSocketConnectionsHandler
         .acceptHttpUpgradeRequests()
         .subscribe(

--- a/service/src/test/java/org/broadinstitute/listener/relay/http/AvailabilityTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/http/AvailabilityTest.java
@@ -3,13 +3,19 @@ package org.broadinstitute.listener.relay.http;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.microsoft.azure.relay.HybridConnectionListener;
+import org.broadinstitute.listener.StartupHandler;
+import org.broadinstitute.listener.relay.ListenerException;
 import org.broadinstitute.listener.relay.health.HybridConnectionListenerHealth;
+import org.broadinstitute.listener.relay.transport.RelayedRequestPipeline;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,12 +45,18 @@ class AvailabilityTest {
   @Autowired private ApplicationContext context;
   @Autowired private ApplicationAvailability applicationAvailability;
   @Autowired private HybridConnectionListenerHealth hybridConnectionListenerHealth;
+  @Autowired private StartupHandler startupHandler;
 
   @MockBean private HybridConnectionListener hybridConnectionListener;
+  @MockBean private RelayedRequestPipeline relayedRequestPipeline;
 
   @BeforeEach
   void beforeEach() {
     when(hybridConnectionListener.isOnline()).thenReturn(true);
+    doNothing().when(relayedRequestPipeline).processRelayedRequests();
+    // set liveness and readiness to ok before each test; prevents crosstalk between tests
+    AvailabilityChangeEvent.publish(context, LivenessState.CORRECT);
+    AvailabilityChangeEvent.publish(context, ReadinessState.ACCEPTING_TRAFFIC);
   }
 
   // Reference: https://www.baeldung.com/spring-liveness-readiness-probes
@@ -126,5 +138,39 @@ class AvailabilityTest {
         "Liveness state should be CORRECT",
         applicationAvailability.getLivenessState(),
         equalTo(LivenessState.CORRECT));
+  }
+
+  /**
+   * Verify that an error during startup sets liveness state to broken.
+   *
+   * @throws Exception on exception in the test
+   */
+  @Test
+  void processRelayedRequestsError() throws Exception {
+    // livenessState and liveness probe should both be ok, to start
+    assertThat(
+        "Liveness state should be CORRECT",
+        applicationAvailability.getLivenessState(),
+        equalTo(LivenessState.CORRECT));
+    ResultActions result = mvc.perform(get("/actuator/health/liveness"));
+    result.andExpect(status().isOk()).andExpect(jsonPath("$.status").value("UP"));
+    ResultActions livenessResult = mvc.perform(get("/actuator/health/liveness"));
+    livenessResult.andExpect(status().isOk()).andExpect(jsonPath("$.status").value("UP"));
+
+    // mock processRelayedRequests to throw an exception
+    doThrow(new RuntimeException("intentional failure for unit test"))
+        .when(relayedRequestPipeline)
+        .processRelayedRequests();
+    // and re-run the startup handler, mimicking startup
+    assertThrows(ListenerException.class, () -> startupHandler.startProcessingRequests());
+
+    // liveness state and liveness probe should now show failure
+    assertThat(
+        "Liveness state should be BROKEN",
+        applicationAvailability.getLivenessState(),
+        equalTo(LivenessState.BROKEN));
+    mvc.perform(get("/actuator/health/liveness"))
+        .andExpect(status().isServiceUnavailable())
+        .andExpect(jsonPath("$.status").value("DOWN"));
   }
 }

--- a/service/src/test/java/org/broadinstitute/listener/relay/http/AvailabilityTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/http/AvailabilityTest.java
@@ -152,8 +152,6 @@ class AvailabilityTest {
         "Liveness state should be CORRECT",
         applicationAvailability.getLivenessState(),
         equalTo(LivenessState.CORRECT));
-    ResultActions result = mvc.perform(get("/actuator/health/liveness"));
-    result.andExpect(status().isOk()).andExpect(jsonPath("$.status").value("UP"));
     ResultActions livenessResult = mvc.perform(get("/actuator/health/liveness"));
     livenessResult.andExpect(status().isOk()).andExpect(jsonPath("$.status").value("UP"));
 


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/AJ-1550

## Summary of changes:
* Trap exceptions in the StartupHandler. If startup fails, set liveness state to broken so k8s will restart the pod.
* Change a few logging statements from debug to info for increased visibility.

### Why
It seems that if the listener runs into certain errors - specifically, we've seen problems with java.util.concurrent.TimeoutException: DNS timeout 15000 ms - the listener never connects to Relay, but startup still continues and liveness/readiness remain ok. This leaves the listener in a non-functional state (it isn't listening for requests) eternally.


### Testing strategy
- [x] Added a unit test
- [ ] I still can't reproduce the "DNS timeout 15000 ms" error on request. I can get this code into a running AKS and verify that other problems during startup will trigger k8s restarts.

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
