### PR TITLE
[TOAZ-340] Remove spring-boot devtools

### DIFF
--- a/service/spring.gradle
+++ b/service/spring.gradle
@@ -2,7 +2,6 @@ configurations { compileOnly { extendsFrom annotationProcessor } }
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/TOAZ-340

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
Disable `devtools` in the listener. Slack thread: https://broadinstitute.slack.com/archives/C05BYVBM2HE/p1707757014406499

### What
- `devtools` was mistakenly enabled in the live/prod deployment of the listener, due to an interaction with `jib`. This was causing slower startup and restarts in listener deployments.

### Why
I found this when I was testing stuff in a UAE region. `devtools` was kicking in and restarting the Listener (maybe because I was mistakenly using a smaller machine type). I don't think people use `devtools` locally anyway, so let's just remove it. Note WDS did the same: https://github.com/DataBiosphere/terra-workspace-data-service/pull/334

### Testing strategy
- [x] Deployed this change in a BEE and successfully started WDS and workflows apps

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
