### PR TITLE
[WOR-1517] Remove workspace-level READ check 

### DIFF
--- a/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
+++ b/service/src/main/java/org/broadinstitute/listener/config/AppConfiguration.java
@@ -43,7 +43,6 @@ public class AppConfiguration {
   @Bean
   public SamResourceClient samResourceClient(TokenChecker tokenChecker) {
     return new SamResourceClient(
-        properties.getSetDateAccessedInspectorProperties().workspaceId(),
         properties.getSamInspectorProperties().samUrl(),
         properties.getSamInspectorProperties().samResourceId(),
         properties.getSamInspectorProperties().samResourceType(),

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SamResourceClient.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SamResourceClient.java
@@ -3,7 +3,6 @@ package org.broadinstitute.listener.relay.inspectors;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.time.Instant;
-import java.util.UUID;
 import okhttp3.OkHttpClient;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
@@ -14,7 +13,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.cache.annotation.Cacheable;
 
 public class SamResourceClient {
-  private final UUID workspaceId;
   private final String samUrl;
   private final String samResourceId;
   private final String samResourceType;
@@ -25,13 +23,11 @@ public class SamResourceClient {
   private final Logger logger = LoggerFactory.getLogger(SamResourceClient.class);
 
   public SamResourceClient(
-      UUID workspaceId,
       String samUrl,
       String samResourceId,
       String samResourceType,
       TokenChecker tokenChecker,
       String samAction) {
-    this.workspaceId = workspaceId;
     this.samUrl = samUrl;
     this.samResourceId = samResourceId;
     this.samResourceType = samResourceType;

--- a/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SamResourceClient.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/inspectors/SamResourceClient.java
@@ -50,14 +50,6 @@ public class SamResourceClient {
         var apiClient = getApiClient(accessToken);
         var resourceApi = new ResourcesApi(apiClient);
 
-        // check that user has access to workspace
-        boolean workspaceAccess =
-            resourceApi.resourcePermissionV2("workspace", workspaceId.toString(), "read");
-        if (!workspaceAccess) {
-          logger.error("Unauthorized request. User doesn't have access to workspace.");
-          return Instant.EPOCH;
-        }
-
         var res = resourceApi.resourcePermissionV2(samResourceType, samResourceId, samAction);
         if (res) return oauthInfo.expiresAt().get();
         else {

--- a/service/src/test/java/org/broadinstitute/listener/relay/inspectors/SamResourceClientTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/inspectors/SamResourceClientTest.java
@@ -15,7 +15,6 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.ApiResponse;
@@ -36,8 +35,7 @@ class SamResourceClientTest {
 
   @Spy
   private SamResourceClient samResourceClient =
-      new SamResourceClient(
-          UUID.randomUUID(), "samUrl", "resourceId", "resourceType", tokenChecker, "myaction");
+      new SamResourceClient("samUrl", "resourceId", "resourceType", tokenChecker, "myaction");
 
   @BeforeEach
   void setUp() throws IOException, InterruptedException, ApiException {

--- a/service/src/test/java/org/broadinstitute/listener/relay/inspectors/SamResourceClientTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/inspectors/SamResourceClientTest.java
@@ -74,23 +74,6 @@ class SamResourceClientTest {
   }
 
   @Test
-  void checkPermission_no_workspace_access()
-      throws IOException, InterruptedException, ApiException {
-    var expiresAt = Instant.now().plusSeconds(100);
-    var oauthResponse =
-        new OauthInfo(Optional.of(expiresAt), "", Map.of("email", "example@example.com"));
-    // check for workspace read access returns false
-    var apiResponse = new ApiResponse(200, Map.of(), false);
-
-    when(tokenChecker.getOauthInfo(any())).thenReturn(oauthResponse);
-    when(apiClient.execute(any(), any())).thenReturn(apiResponse);
-    when(apiClient.escapeString(any())).thenReturn("string");
-
-    var res = samResourceClient.checkPermission("accessToken");
-    assertThat(res, equalTo(Instant.EPOCH));
-  }
-
-  @Test
   void isUserEnabled_enabled() throws ApiException {
     var apiResponse = new ApiResponse(200, Map.of(), new UserStatusInfo().enabled(true));
     when(apiClient.execute(any(), any())).thenReturn(apiResponse);


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/WOR-1517

<!-- ### Dependencies --->
<!-- Include any dependent tickets and describe the relationship. Include any relevant Jira tickets. --->

## Summary of changes:
* Removes the `READ` check for workspace access

### What
- We do not want a workspace read check as that will not succeed for the Leonardo SA when an auth domain is present on the workspace

### Why
[Related doc](https://docs.google.com/document/d/16Gfjxx4QH2IiTSDUgIb5hzMtOlI4i62_-5NVjBDO8kY/edit#heading=h.4dgk7j6qvmuw)
- Leo uses it's own SA identity to poll on resource operations within an MRG, such as welder and jupyter. However, `READ` is auth domain constrainable. When an auth domain is applied to the workspace, the `SamResourceClient`'s  `READ` check will fail and Leo will not be able to perform the needed operations. Since there is [no longer](https://github.com/DataBiosphere/leonardo/pull/3488) a direct policy applied to apps in a workspace, the inheritance from the workspace will be enough to ensure those removed from a workspace no longer have access to shared apps.
 

### Testing strategy
- [x] Verify removed users do not have access to `kubernetes-shared-app`s
     * Create a workspace in a bee with this relay version
     * Verify WDS, workflows and CE's function as expected
     * Add a second user to the workspace
     * Verify user has access to the kubernetes-shared-apps in the workspace by making a direct call to the relay 
     * Remove the user from the workspace
     * Verify user does not have access to the kubernetes-shared-apps in the workspace by making a direct call to the relay and observe a 403

###  Evidence from bee testing:

Call to get workflow methods: 

```
GET https://lzfaadbbf2ee14907c221c01281f7ceba9d482423ef4b2b039.servicebus.windows.net/terra-app-9703ea0c-fb8e-455e-94a3-213ebf2b412f-85d58d58-5994-4a47-9308-4ad7e9abe367/cbas/api/batch/v1/methods?show_versions=true

HTTP/1.1 200 OK
```
  
 Call to get after removal from workspace: 

``` 
GET https://lzfaadbbf2ee14907c221c01281f7ceba9d482423ef4b2b039.servicebus.windows.net/terra-app-9703ea0c-fb8e-455e-94a3-213ebf2b412f-85d58d58-5994-4a47-9308-4ad7e9abe367/cbas/api/batch/v1/methods?show_versions=true

HTTP/1.1 403 The listener rejected the request. Tracking ID:0b5dcbdb-a60c-40bf-88bb-76e20e5d99dc_G27```
````
 

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
