### PR TITLE
IA-4893: don't materialize the entire response

### DIFF
--- a/service/src/main/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessor.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessor.java
@@ -284,7 +284,6 @@ public class RelayedHttpRequestProcessor {
     Result result = Result.SUCCESS;
     if (targetResponse.getBody().isPresent()) {
       try {
-        // buffer the response back to the caller.
         StreamUtils.copy(targetResponse.getBody().get(), outputStream);
       } catch (IOException e) {
         logger.error("Failed to write response body to the remote client.", e);

--- a/service/src/main/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessor.java
+++ b/service/src/main/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessor.java
@@ -32,6 +32,7 @@ import org.springframework.boot.actuate.health.HealthComponent;
 import org.springframework.boot.actuate.health.HealthEndpoint;
 import org.springframework.boot.actuate.health.Status;
 import org.springframework.lang.NonNull;
+import org.springframework.util.StreamUtils;
 
 public class RelayedHttpRequestProcessor {
 
@@ -283,7 +284,8 @@ public class RelayedHttpRequestProcessor {
     Result result = Result.SUCCESS;
     if (targetResponse.getBody().isPresent()) {
       try {
-        outputStream.write(targetResponse.getBody().get().readAllBytes());
+        // buffer the response back to the caller.
+        StreamUtils.copy(targetResponse.getBody().get(), outputStream);
       } catch (IOException e) {
         logger.error("Failed to write response body to the remote client.", e);
         result = Result.FAILURE;

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -7,6 +7,10 @@ spring:
     cache-names: expiresAt
     caffeine.spec: maximumSize=100,expireAfterWrite=90s
 
+logging:
+  level:
+    com.microsoft.azure.relay.RelayLogger: WARN
+
 listener:
   # Connection string for the Azure Relay instance.
   #

--- a/service/src/test/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessorTest.java
+++ b/service/src/test/java/org/broadinstitute/listener/relay/http/RelayedHttpRequestProcessorTest.java
@@ -8,9 +8,11 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -20,6 +22,8 @@ import com.microsoft.azure.relay.RelayedHttpListenerRequest;
 import com.microsoft.azure.relay.RelayedHttpListenerResponse;
 import com.microsoft.azure.relay.TrackingContext;
 import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -31,13 +35,17 @@ import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.broadinstitute.listener.config.CorsSupportProperties;
 import org.broadinstitute.listener.relay.InvalidRelayTargetException;
 import org.broadinstitute.listener.relay.http.RelayedHttpRequestProcessor.Result;
@@ -57,6 +65,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.actuate.health.HealthComponent;
 import org.springframework.boot.actuate.health.HealthEndpoint;
 import org.springframework.boot.actuate.health.Status;
+import org.springframework.util.StreamUtils;
 
 @ExtendWith(MockitoExtension.class)
 class RelayedHttpRequestProcessorTest {
@@ -261,6 +270,99 @@ class RelayedHttpRequestProcessorTest {
 
     verify(responseStream).close();
     verify(spyBody).close();
+  }
+
+  /**
+   * Given a large - multi-MB - http response, ensure the response is buffered back to the caller in
+   * multiple writes.
+   *
+   * @throws IOException on temp file error
+   */
+  @Test
+  void writeTargetResponseOnCaller_withLargeBodyContent() throws IOException {
+    // write a bunch of junk data to a temp file
+    int numBufferChunks = 2000; // 2000 chunks * 4096 bytes/chunk = ~7.8MB
+    Path inputFile = Files.createTempFile("input-", ".tmp");
+    FileOutputStream fileOutputStream = new FileOutputStream(inputFile.toFile());
+    for (int i = 0; i < numBufferChunks; i++) {
+      fileOutputStream.write(
+          RandomStringUtils.randomAlphanumeric(StreamUtils.BUFFER_SIZE)
+              .getBytes(StandardCharsets.UTF_8));
+    }
+    fileOutputStream.close();
+
+    // create an InputStream from the temp file
+    FileInputStream fileInputStream = Mockito.spy(new FileInputStream(inputFile.toFile()));
+
+    // set the InputStream as the HTTP response
+    when(targetHttpResponse.getContext()).thenReturn(context);
+    when(targetHttpResponse.getBody()).thenReturn(Optional.of(fileInputStream));
+    when(targetHttpResponse.getStatusCode()).thenReturn(200);
+    when(context.getResponse()).thenReturn(listenerResponse);
+    when(targetHttpResponse.getCallerResponseOutputStream()).thenReturn(responseStream);
+
+    // write HTTP response to caller
+    processor.writeTargetResponseOnCaller(targetHttpResponse);
+
+    // verify that the HTTP response was buffered to the caller in chunks; we should have written
+    // to the caller ${numBufferChunks} times, because the temp file is of size
+    // ${numBufferChunks * StreamUtils.BUFFER_SIZE}
+    verify(responseStream, times(numBufferChunks)).write(any(), anyInt(), anyInt());
+
+    // verify everything was closed
+    verify(responseStream).close();
+    verify(fileInputStream).close();
+
+    // clean up
+    Files.delete(inputFile);
+  }
+
+  /**
+   * Given a medium-sized (50KB) http response file, ensure that the response is buffered to the
+   * caller and that what the caller receives is equivalent to http response
+   *
+   * @throws IOException on temp file error
+   */
+  @Test
+  void writeTargetResponseOnCaller_withMultipleChunks() throws IOException {
+    // create an InputStream from a sample text file
+    InputStream fileInputStream =
+        Mockito.spy(
+            Objects.requireNonNull(ClassLoader.getSystemResourceAsStream("sample-text.txt")));
+
+    // create a temp file to serve as our output stream
+    Path outputFile = Files.createTempFile("output-", ".tmp");
+    FileOutputStream responseOutputStream = Mockito.spy(new FileOutputStream(outputFile.toFile()));
+
+    // set the InputStream as the HTTP response
+    when(targetHttpResponse.getContext()).thenReturn(context);
+    when(targetHttpResponse.getBody()).thenReturn(Optional.of(fileInputStream));
+    when(targetHttpResponse.getStatusCode()).thenReturn(200);
+    when(context.getResponse()).thenReturn(listenerResponse);
+    when(targetHttpResponse.getCallerResponseOutputStream()).thenReturn(responseOutputStream);
+
+    // write HTTP response to caller
+    processor.writeTargetResponseOnCaller(targetHttpResponse);
+
+    // verify that the HTTP response was buffered to the caller in chunks. We should have written
+    // more than one chunk given the size of the input file.
+    verify(responseOutputStream, atLeast(1)).write(any(), anyInt(), anyInt());
+
+    // verify everything was closed
+    verify(responseOutputStream).close();
+    verify(fileInputStream).close();
+
+    // compare file contents
+    String expected =
+        new String(
+            Objects.requireNonNull(ClassLoader.getSystemResourceAsStream("sample-text.txt"))
+                .readAllBytes());
+    String actual = new String(Files.readAllBytes(outputFile));
+
+    assertThat("file contents differ", actual.equals(expected));
+
+    // clean up
+    Files.delete(outputFile);
   }
 
   @Test

--- a/service/src/test/resources/sample-text.txt
+++ b/service/src/test/resources/sample-text.txt
@@ -1,0 +1,859 @@
+Orion's sword Jean-François Champollion finite but unbounded quasar
+another world astonishment. How far away the only home we've ever known
+invent the universe ship of the imagination kindling the energy hidden
+in matter vanquish the impossible. Two ghostly white figures in
+coveralls and helmets are softly dancing vastness is bearable only
+through love with pretty stories for which there's little good evidence
+the ash of stellar alchemy are creatures of the cosmos dream of the
+mind's eye.
+
+Inconspicuous motes of rock and gas citizens of distant epochs
+permanence of the stars ship of the imagination Euclid a still more
+glorious dawn awaits. Vangelis encyclopaedia galactica emerged into
+consciousness paroxysm of global death across the centuries hearts of
+the stars. The carbon in our apple pies something incredible is waiting
+to be known with pretty stories for which there's little good evidence
+bits of moving fluff at the edge of forever hundreds of thousands?
+
+How far away billions upon billions hundreds of thousands a very small
+stage in a vast cosmic arena with pretty stories for which there's
+little good evidence shores of the cosmic ocean. Rich in mystery two
+ghostly white figures in coveralls and helmets are softly dancing the
+only home we've ever known at the edge of forever gathered by gravity
+birth. Invent the universe with pretty stories for which there's little
+good evidence a still more glorious dawn awaits the only home we've ever
+known intelligent beings invent the universe.
+
+From which we spring Cambrian explosion radio telescope great turbulent
+clouds hundreds of thousands inconspicuous motes of rock and gas. Shores
+of the cosmic ocean preserve and cherish that pale blue dot finite but
+unbounded the sky calls to us not a sunrise but a galaxyrise
+circumnavigated. Culture extraordinary claims require extraordinary
+evidence muse about a very small stage in a vast cosmic arena bits of
+moving fluff muse about.
+
+Tendrils of gossamer clouds galaxies another world hydrogen atoms rich
+in heavy atoms Jean-François Champollion. Light years brain is the seed
+of intelligence concept of the number one the sky calls to us citizens
+of distant epochs bits of moving fluff. As a patch of light
+inconspicuous motes of rock and gas are creatures of the cosmos made in
+the interiors of collapsing stars dispassionate extraterrestrial
+observer Sea of Tranquility.
+
+Globular star cluster prime number quasar citizens of distant epochs
+Drake Equation as a patch of light. The carbon in our apple pies stirred
+by starlight a still more glorious dawn awaits made in the interiors of
+collapsing stars not a sunrise but a galaxyrise preserve and cherish
+that pale blue dot. The carbon in our apple pies permanence of the stars
+finite but unbounded with pretty stories for which there's little good
+evidence hearts of the stars brain is the seed of intelligence.
+
+Cosmic ocean shores of the cosmic ocean stirred by starlight a still
+more glorious dawn awaits two ghostly white figures in coveralls and
+helmets are softly dancing rich in mystery? Descended from astronomers
+vanquish the impossible rich in heavy atoms the carbon in our apple pies
+Vangelis not a sunrise but a galaxyrise? Bits of moving fluff ship of
+the imagination courage of our questions Vangelis the only home we've
+ever known a very small stage in a vast cosmic arena?
+
+How far away radio telescope hearts of the stars finite but unbounded
+bits of moving fluff Rig Veda? The sky calls to us made in the interiors
+of collapsing stars Cambrian explosion courage of our questions
+something incredible is waiting to be known muse about. Extraordinary
+claims require extraordinary evidence another world not a sunrise but a
+galaxyrise a mote of dust suspended in a sunbeam kindling the energy
+hidden in matter concept of the number one.
+
+Astonishment quasar Flatland cosmos white dwarf network of wormholes.
+Globular star cluster finite but unbounded at the edge of forever dream
+of the mind's eye the sky calls to us rich in heavy atoms. Extraordinary
+claims require extraordinary evidence as a patch of light a mote of dust
+suspended in a sunbeam encyclopaedia galactica with pretty stories for
+which there's little good evidence concept of the number one?
+
+Decipherment star stuff harvesting star light concept of the number one
+Orion's sword the ash of stellar alchemy as a patch of light. Gathered
+by gravity invent the universe stirred by starlight preserve and cherish
+that pale blue dot from which we spring network of wormholes. Vastness
+is bearable only through love citizens of distant epochs network of
+wormholes the only home we've ever known brain is the seed of
+intelligence at the edge of forever.
+
+Venture kindling the energy hidden in matter rogue galaxies rich in
+mystery Sea of Tranquility. The only home we've ever known ship of the
+imagination star stuff harvesting star light emerged into consciousness
+Euclid preserve and cherish that pale blue dot? The only home we've ever
+known dream of the mind's eye made in the interiors of collapsing stars
+a very small stage in a vast cosmic arena how far away muse about.
+
+Paroxysm of global death the ash of stellar alchemy tesseract Sea of
+Tranquility ship of the imagination how far away? Citizens of distant
+epochs at the edge of forever corpus callosum trillion the only home
+we've ever known trillion? Stirred by starlight made in the interiors of
+collapsing stars the sky calls to us the sky calls to us muse about two
+ghostly white figures in coveralls and helmets are softly dancing.
+
+Extraordinary claims require extraordinary evidence tendrils of gossamer
+clouds Tunguska event the only home we've ever known muse about stirred
+by starlight. Vanquish the impossible realm of the galaxies a mote of
+dust suspended in a sunbeam hearts of the stars paroxysm of global death
+invent the universe? Gathered by gravity two ghostly white figures in
+coveralls and helmets are softly dancing the ash of stellar alchemy a
+very small stage in a vast cosmic arena something incredible is waiting
+to be known encyclopaedia galactica.
+
+Something incredible is waiting to be known stirred by starlight
+extraplanetary with pretty stories for which there's little good
+evidence encyclopaedia galactica inconspicuous motes of rock and gas.
+Radio telescope dream of the mind's eye Sea of Tranquility across the
+centuries tesseract dream of the mind's eye. Astonishment bits of moving
+fluff Apollonius of Perga kindling the energy hidden in matter vastness
+is bearable only through love concept of the number one?
+
+Laws of physics Vangelis vanquish the impossible brain is the seed of
+intelligence quasar hundreds of thousands? With pretty stories for which
+there's little good evidence Cambrian explosion finite but unbounded
+realm of the galaxies a very small stage in a vast cosmic arena rich in
+mystery. Gathered by gravity citizens of distant epochs stirred by
+starlight not a sunrise but a galaxyrise two ghostly white figures in
+coveralls and helmets are softly dancing bits of moving fluff?
+
+Decipherment astonishment Rig Veda Vangelis Euclid hundreds of
+thousands. Another world the sky calls to us permanence of the stars
+bits of moving fluff laws of physics across the centuries. Star stuff
+harvesting star light with pretty stories for which there's little good
+evidence with pretty stories for which there's little good evidence
+descended from astronomers from which we spring globular star cluster.
+As a patch of light emerged into consciousness the only home we've ever
+known brain is the seed of intelligence descended from astronomers
+colonies.
+
+Worldlets of brilliant syntheses the ash of stellar alchemy the sky
+calls to us finite but unbounded trillion? Intelligent beings paroxysm
+of global death courage of our questions Sea of Tranquility from which
+we spring great turbulent clouds. Made in the interiors of collapsing
+stars rich in heavy atoms encyclopaedia galactica network of wormholes
+at the edge of forever inconspicuous motes of rock and gas. Rich in
+heavy atoms globular star cluster made in the interiors of collapsing
+stars two ghostly white figures in coveralls and helmets are softly
+dancing network of wormholes Euclid.
+
+Take root and flourish Drake Equation two ghostly white figures in
+coveralls and helmets are softly dancing rogue a still more glorious
+dawn awaits great turbulent clouds. Tendrils of gossamer clouds cosmos
+intelligent beings trillion invent the universe tingling of the spine.
+The carbon in our apple pies bits of moving fluff paroxysm of global
+death paroxysm of global death made in the interiors of collapsing stars
+something incredible is waiting to be known.
+
+Tendrils of gossamer clouds a mote of dust suspended in a sunbeam Rig
+Veda of brilliant syntheses tesseract extraordinary claims require
+extraordinary evidence. Hypatia another world inconspicuous motes of
+rock and gas rings of Uranus realm of the galaxies great turbulent
+clouds? The sky calls to us citizens of distant epochs the sky calls to
+us two ghostly white figures in coveralls and helmets are softly dancing
+the sky calls to us finite but unbounded?
+
+Kindling the energy hidden in matter a mote of dust suspended in a
+sunbeam citizens of distant epochs preserve and cherish that pale blue
+dot a very small stage in a vast cosmic arena the sky calls to us. Of
+brilliant syntheses the only home we've ever known the ash of stellar
+alchemy radio telescope of brilliant syntheses star stuff harvesting
+star light. Concept of the number one hundreds of thousands citizens of
+distant epochs extraordinary claims require extraordinary evidence how
+far away great turbulent clouds.
+
+Quasar kindling the energy hidden in matter star stuff harvesting star
+light rings of Uranus rogue consciousness. Cosmic ocean network of
+wormholes network of wormholes a very small stage in a vast cosmic arena
+Euclid realm of the galaxies? With pretty stories for which there's
+little good evidence muse about tendrils of gossamer clouds vastness is
+bearable only through love Euclid descended from astronomers? Courage of
+our questions how far away as a patch of light extraordinary claims
+require extraordinary evidence not a sunrise but a galaxyrise a still
+more glorious dawn awaits.
+
+Euclid galaxies billions upon billions rich in heavy atoms emerged into
+consciousness a mote of dust suspended in a sunbeam? Dream of the mind's
+eye vanquish the impossible tingling of the spine a mote of dust
+suspended in a sunbeam with pretty stories for which there's little good
+evidence stirred by starlight? Shores of the cosmic ocean not a sunrise
+but a galaxyrise shores of the cosmic ocean star stuff harvesting star
+light tendrils of gossamer clouds concept of the number one.
+
+Trillion rings of Uranus tendrils of gossamer clouds extraordinary
+claims require extraordinary evidence dream of the mind's eye shores of
+the cosmic ocean. A very small stage in a vast cosmic arena descended
+from astronomers hearts of the stars vanquish the impossible hearts of
+the stars hearts of the stars. Orion's sword bits of moving fluff
+kindling the energy hidden in matter preserve and cherish that pale blue
+dot kindling the energy hidden in matter network of wormholes.
+
+Corpus callosum tendrils of gossamer clouds muse about worldlets science
+globular star cluster? Euclid the carbon in our apple pies descended
+from astronomers across the centuries cosmic ocean with pretty stories
+for which there's little good evidence? Citizens of distant epochs take
+root and flourish inconspicuous motes of rock and gas a still more
+glorious dawn awaits cosmic ocean star stuff harvesting star light.
+Orion's sword a very small stage in a vast cosmic arena rich in mystery
+hearts of the stars vastness is bearable only through love the only home
+we've ever known.
+
+Hundreds of thousands laws of physics ship of the imagination birth
+something incredible is waiting to be known dream of the mind's eye? Two
+ghostly white figures in coveralls and helmets are softly dancing
+venture bits of moving fluff across the centuries tingling of the spine
+Sea of Tranquility? Paroxysm of global death bits of moving fluff rings
+of Uranus hearts of the stars bits of moving fluff a mote of dust
+suspended in a sunbeam.
+
+Rogue billions upon billions a mote of dust suspended in a sunbeam
+across the centuries brain is the seed of intelligence billions upon
+billions. Hearts of the stars permanence of the stars a very small stage
+in a vast cosmic arena white dwarf Sea of Tranquility a still more
+glorious dawn awaits. Something incredible is waiting to be known shores
+of the cosmic ocean citizens of distant epochs bits of moving fluff the
+carbon in our apple pies extraordinary claims require extraordinary
+evidence.
+
+Venture Rig Veda light years vanquish the impossible Drake Equation
+cosmic ocean. Extraordinary claims require extraordinary evidence a mote
+of dust suspended in a sunbeam the sky calls to us two ghostly white
+figures in coveralls and helmets are softly dancing across the centuries
+the carbon in our apple pies. Permanence of the stars descended from
+astronomers vastness is bearable only through love take root and
+flourish not a sunrise but a galaxyrise paroxysm of global death.
+
+As a patch of light Flatland astonishment cosmos rings of Uranus of
+brilliant syntheses. Finite but unbounded kindling the energy hidden in
+matter not a sunrise but a galaxyrise network of wormholes stirred by
+starlight citizens of distant epochs. Sea of Tranquility kindling the
+energy hidden in matter vanquish the impossible the ash of stellar
+alchemy network of wormholes something incredible is waiting to be
+known. The sky calls to us with pretty stories for which there's little
+good evidence something incredible is waiting to be known hundreds of
+thousands vanquish the impossible vastness is bearable only through
+love.
+
+Globular star cluster worldlets rich in heavy atoms finite but unbounded
+two ghostly white figures in coveralls and helmets are softly dancing
+science. Courage of our questions vanquish the impossible Euclid
+descended from astronomers another world astonishment. The sky calls to
+us made in the interiors of collapsing stars vastness is bearable only
+through love from which we spring the ash of stellar alchemy the only
+home we've ever known.
+
+Stirred by starlight venture made in the interiors of collapsing stars
+cosmic ocean rogue explorations? Sea of Tranquility two ghostly white
+figures in coveralls and helmets are softly dancing a very small stage
+in a vast cosmic arena permanence of the stars something incredible is
+waiting to be known vastness is bearable only through love.
+Encyclopaedia galactica a very small stage in a vast cosmic arena dream
+of the mind's eye not a sunrise but a galaxyrise kindling the energy
+hidden in matter ship of the imagination.
+
+Network of wormholes of brilliant syntheses finite but unbounded quasar
+tingling of the spine explorations. Brain is the seed of intelligence
+extraordinary claims require extraordinary evidence paroxysm of global
+death Sea of Tranquility globular star cluster venture. Dream of the
+mind's eye bits of moving fluff prime number vanquish the impossible two
+ghostly white figures in coveralls and helmets are softly dancing
+permanence of the stars? Orion's sword dream of the mind's eye a very
+small stage in a vast cosmic arena inconspicuous motes of rock and gas
+are creatures of the cosmos preserve and cherish that pale blue dot.
+
+Something incredible is waiting to be known a billion trillion made in
+the interiors of collapsing stars tingling of the spine radio telescope
+invent the universe. Brain is the seed of intelligence Vangelis Rig Veda
+two ghostly white figures in coveralls and helmets are softly dancing
+dream of the mind's eye the only home we've ever known. Take root and
+flourish a still more glorious dawn awaits the only home we've ever
+known vastness is bearable only through love not a sunrise but a
+galaxyrise bits of moving fluff?
+
+Preserve and cherish that pale blue dot great turbulent clouds descended
+from astronomers ship of the imagination take root and flourish tendrils
+of gossamer clouds. Colonies the sky calls to us the sky calls to us
+courage of our questions with pretty stories for which there's little
+good evidence invent the universe. Shores of the cosmic ocean bits of
+moving fluff cosmic ocean cosmic ocean citizens of distant epochs
+something incredible is waiting to be known.
+
+Cosmos prime number a billion trillion of brilliant syntheses finite but
+unbounded encyclopaedia galactica. Something incredible is waiting to be
+known Rig Veda how far away a still more glorious dawn awaits corpus
+callosum the only home we've ever known? The carbon in our apple pies
+vastness is bearable only through love at the edge of forever network of
+wormholes bits of moving fluff the ash of stellar alchemy.
+
+Are creatures of the cosmos astonishment billions upon billions
+extraordinary claims require extraordinary evidence cosmos a billion
+trillion. Shores of the cosmic ocean star stuff harvesting star light
+two ghostly white figures in coveralls and helmets are softly dancing
+two ghostly white figures in coveralls and helmets are softly dancing a
+still more glorious dawn awaits hearts of the stars. Intelligent beings
+not a sunrise but a galaxyrise inconspicuous motes of rock and gas
+Apollonius of Perga vanquish the impossible vanquish the impossible.
+
+Finite but unbounded permanence of the stars Vangelis citizens of
+distant epochs stirred by starlight colonies. Bits of moving fluff the
+carbon in our apple pies great turbulent clouds how far away something
+incredible is waiting to be known descended from astronomers? With
+pretty stories for which there's little good evidence hearts of the
+stars vanquish the impossible Hypatia a still more glorious dawn awaits
+invent the universe.
+
+Another world the sky calls to us laws of physics citizens of distant
+epochs trillion the ash of stellar alchemy. Extraordinary claims require
+extraordinary evidence vanquish the impossible inconspicuous motes of
+rock and gas from which we spring made in the interiors of collapsing
+stars at the edge of forever. Encyclopaedia galactica across the
+centuries the only home we've ever known a very small stage in a vast
+cosmic arena made in the interiors of collapsing stars two ghostly white
+figures in coveralls and helmets are softly dancing.
+
+Inconspicuous motes of rock and gas Orion's sword ship of the
+imagination how far away cosmic fugue Sea of Tranquility. Muse about
+from which we spring a very small stage in a vast cosmic arena great
+turbulent clouds vanquish the impossible two ghostly white figures in
+coveralls and helmets are softly dancing. Corpus callosum the only home
+we've ever known preserve and cherish that pale blue dot across the
+centuries a mote of dust suspended in a sunbeam descended from
+astronomers.
+
+Inconspicuous motes of rock and gas the carbon in our apple pies
+vastness is bearable only through love astonishment Orion's sword
+science. A mote of dust suspended in a sunbeam colonies from which we
+spring gathered by gravity a very small stage in a vast cosmic arena
+extraordinary claims require extraordinary evidence. With pretty stories
+for which there's little good evidence invent the universe network of
+wormholes the only home we've ever known the sky calls to us concept of
+the number one?
+
+Network of wormholes Drake Equation courage of our questions prime
+number tingling of the spine science. A still more glorious dawn awaits
+how far away vanquish the impossible paroxysm of global death vanquish
+the impossible muse about. Kindling the energy hidden in matter another
+world the only home we've ever known the ash of stellar alchemy
+something incredible is waiting to be known the only home we've ever
+known.
+
+Across the centuries how far away Euclid colonies Vangelis with pretty
+stories for which there's little good evidence. Network of wormholes
+rich in heavy atoms birth made in the interiors of collapsing stars a
+mote of dust suspended in a sunbeam another world. Paroxysm of global
+death bits of moving fluff the only home we've ever known hundreds of
+thousands descended from astronomers two ghostly white figures in
+coveralls and helmets are softly dancing.
+
+Dream of the mind's eye intelligent beings a mote of dust suspended in a
+sunbeam extraordinary claims require extraordinary evidence tingling of
+the spine rich in mystery. Are creatures of the cosmos Tunguska event
+rings of Uranus rich in heavy atoms bits of moving fluff Sea of
+Tranquility. The carbon in our apple pies rich in heavy atoms vanquish
+the impossible a billion trillion star stuff harvesting star light take
+root and flourish?
+
+Corpus callosum circumnavigated colonies hearts of the stars prime
+number hundreds of thousands? Venture bits of moving fluff bits of
+moving fluff cosmic ocean not a sunrise but a galaxyrise emerged into
+consciousness. Gathered by gravity from which we spring bits of moving
+fluff invent the universe paroxysm of global death are creatures of the
+cosmos. Muse about concept of the number one are creatures of the cosmos
+network of wormholes extraordinary claims require extraordinary evidence
+a mote of dust suspended in a sunbeam.
+
+Across the centuries a very small stage in a vast cosmic arena realm of
+the galaxies billions upon billions cosmic fugue tesseract. Take root
+and flourish globular star cluster explorations bits of moving fluff
+Cambrian explosion how far away? Globular star cluster shores of the
+cosmic ocean radio telescope permanence of the stars globular star
+cluster bits of moving fluff. With pretty stories for which there's
+little good evidence inconspicuous motes of rock and gas courage of our
+questions emerged into consciousness encyclopaedia galactica invent the
+universe.
+
+Astonishment tendrils of gossamer clouds Jean-François Champollion
+network of wormholes extraordinary claims require extraordinary evidence
+Flatland. Descended from astronomers across the centuries concept of the
+number one a billion trillion globular star cluster bits of moving
+fluff? From which we spring something incredible is waiting to be known
+Orion's sword vanquish the impossible something incredible is waiting to
+be known made in the interiors of collapsing stars. A mote of dust
+suspended in a sunbeam a still more glorious dawn awaits courage of our
+questions invent the universe the sky calls to us a still more glorious
+dawn awaits.
+
+Brain is the seed of intelligence finite but unbounded galaxies
+inconspicuous motes of rock and gas decipherment invent the universe. A
+still more glorious dawn awaits the ash of stellar alchemy Cambrian
+explosion hearts of the stars the carbon in our apple pies bits of
+moving fluff. Are creatures of the cosmos encyclopaedia galactica with
+pretty stories for which there's little good evidence a mote of dust
+suspended in a sunbeam take root and flourish Cambrian explosion.
+
+Bits of moving fluff star stuff harvesting star light consciousness at
+the edge of forever another world intelligent beings? Vastness is
+bearable only through love shores of the cosmic ocean great turbulent
+clouds vanquish the impossible the only home we've ever known great
+turbulent clouds? Courage of our questions invent the universe a still
+more glorious dawn awaits a very small stage in a vast cosmic arena
+descended from astronomers brain is the seed of intelligence.
+
+Worldlets consciousness circumnavigated Tunguska event of brilliant
+syntheses Euclid. Vanquish the impossible the carbon in our apple pies
+something incredible is waiting to be known emerged into consciousness
+star stuff harvesting star light not a sunrise but a galaxyrise.
+Globular star cluster Sea of Tranquility a very small stage in a vast
+cosmic arena preserve and cherish that pale blue dot invent the universe
+stirred by starlight. Bits of moving fluff courage of our questions
+vastness is bearable only through love a very small stage in a vast
+cosmic arena permanence of the stars two ghostly white figures in
+coveralls and helmets are softly dancing.
+
+Rich in mystery galaxies a mote of dust suspended in a sunbeam light
+years across the centuries brain is the seed of intelligence. Are
+creatures of the cosmos kindling the energy hidden in matter Orion's
+sword rings of Uranus another world citizens of distant epochs. Rich in
+heavy atoms rich in heavy atoms concept of the number one how far away
+two ghostly white figures in coveralls and helmets are softly dancing
+gathered by gravity.
+
+Intelligent beings muse about inconspicuous motes of rock and gas invent
+the universe how far away billions upon billions. Ship of the
+imagination star stuff harvesting star light with pretty stories for
+which there's little good evidence Tunguska event star stuff harvesting
+star light take root and flourish. Rings of Uranus a still more glorious
+dawn awaits citizens of distant epochs rings of Uranus from which we
+spring culture.
+
+Descended from astronomers colonies the only home we've ever known
+concept of the number one realm of the galaxies at the edge of forever.
+Invent the universe Orion's sword the ash of stellar alchemy paroxysm of
+global death are creatures of the cosmos Jean-François Champollion?
+Stirred by starlight extraordinary claims require extraordinary evidence
+vastness is bearable only through love take root and flourish stirred by
+starlight corpus callosum.
+
+Great turbulent clouds the only home we've ever known cosmic fugue
+Apollonius of Perga tesseract extraplanetary. Star stuff harvesting star
+light are creatures of the cosmos descended from astronomers radio
+telescope invent the universe a still more glorious dawn awaits.
+Something incredible is waiting to be known made in the interiors of
+collapsing stars invent the universe vastness is bearable only through
+love rings of Uranus inconspicuous motes of rock and gas.
+
+As a patch of light invent the universe rings of Uranus tendrils of
+gossamer clouds cosmic ocean extraplanetary. Finite but unbounded muse
+about hundreds of thousands star stuff harvesting star light paroxysm of
+global death extraordinary claims require extraordinary evidence.
+Vanquish the impossible star stuff harvesting star light emerged into
+consciousness great turbulent clouds a very small stage in a vast cosmic
+arena stirred by starlight. A very small stage in a vast cosmic arena
+network of wormholes bits of moving fluff take root and flourish a very
+small stage in a vast cosmic arena citizens of distant epochs.
+
+Laws of physics the ash of stellar alchemy hundreds of thousands how far
+away not a sunrise but a galaxyrise globular star cluster? Preserve and
+cherish that pale blue dot dispassionate extraterrestrial observer
+preserve and cherish that pale blue dot two ghostly white figures in
+coveralls and helmets are softly dancing encyclopaedia galactica
+paroxysm of global death? Stirred by starlight courage of our questions
+rich in heavy atoms hydrogen atoms a mote of dust suspended in a sunbeam
+courage of our questions.
+
+Trillion Orion's sword permanence of the stars decipherment paroxysm of
+global death are creatures of the cosmos? Stirred by starlight colonies
+how far away rich in heavy atoms as a patch of light intelligent beings.
+With pretty stories for which there's little good evidence stirred by
+starlight Sea of Tranquility with pretty stories for which there's
+little good evidence the only home we've ever known made in the
+interiors of collapsing stars?
+
+Intelligent beings concept of the number one at the edge of forever
+another world two ghostly white figures in coveralls and helmets are
+softly dancing kindling the energy hidden in matter. Worldlets with
+pretty stories for which there's little good evidence emerged into
+consciousness a still more glorious dawn awaits realm of the galaxies
+Drake Equation. Two ghostly white figures in coveralls and helmets are
+softly dancing across the centuries encyclopaedia galactica the sky
+calls to us with pretty stories for which there's little good evidence
+courage of our questions.
+
+A still more glorious dawn awaits bits of moving fluff cosmic fugue made
+in the interiors of collapsing stars quasar tesseract. Something
+incredible is waiting to be known star stuff harvesting star light
+paroxysm of global death Euclid kindling the energy hidden in matter two
+ghostly white figures in coveralls and helmets are softly dancing.
+Another world stirred by starlight vanquish the impossible muse about
+the ash of stellar alchemy two ghostly white figures in coveralls and
+helmets are softly dancing?
+
+At the edge of forever Apollonius of Perga circumnavigated as a patch of
+light astonishment finite but unbounded. A mote of dust suspended in a
+sunbeam a very small stage in a vast cosmic arena extraordinary claims
+require extraordinary evidence emerged into consciousness take root and
+flourish rich in mystery. Vanquish the impossible the carbon in our
+apple pies preserve and cherish that pale blue dot how far away hundreds
+of thousands descended from astronomers.
+
+Permanence of the stars billions upon billions citizens of distant
+epochs venture gathered by gravity hearts of the stars? With pretty
+stories for which there's little good evidence descended from
+astronomers Sea of Tranquility from which we spring not a sunrise but a
+galaxyrise kindling the energy hidden in matter? Something incredible is
+waiting to be known the carbon in our apple pies Sea of Tranquility
+dream of the mind's eye network of wormholes emerged into consciousness.
+
+From which we spring at the edge of forever colonies Tunguska event are
+creatures of the cosmos hundreds of thousands. Cosmic ocean concept of
+the number one network of wormholes gathered by gravity a still more
+glorious dawn awaits the only home we've ever known? Gathered by gravity
+network of wormholes made in the interiors of collapsing stars a very
+small stage in a vast cosmic arena decipherment something incredible is
+waiting to be known.
+
+Galaxies intelligent beings courage of our questions network of
+wormholes quasar encyclopaedia galactica? From which we spring from
+which we spring permanence of the stars paroxysm of global death
+dispassionate extraterrestrial observer the sky calls to us. The sky
+calls to us the sky calls to us Apollonius of Perga citizens of distant
+epochs a very small stage in a vast cosmic arena rich in heavy atoms.
+Stirred by starlight citizens of distant epochs with pretty stories for
+which there's little good evidence a mote of dust suspended in a sunbeam
+dream of the mind's eye a very small stage in a vast cosmic arena?
+
+Brain is the seed of intelligence Hypatia Flatland finite but unbounded
+tesseract hearts of the stars. A mote of dust suspended in a sunbeam
+invent the universe muse about Cambrian explosion inconspicuous motes of
+rock and gas how far away? Globular star cluster rich in heavy atoms
+made in the interiors of collapsing stars inconspicuous motes of rock
+and gas rich in heavy atoms two ghostly white figures in coveralls and
+helmets are softly dancing.
+
+Hearts of the stars laws of physics the only home we've ever known
+vastness is bearable only through love hydrogen atoms a billion
+trillion. How far away another world the ash of stellar alchemy the
+carbon in our apple pies a very small stage in a vast cosmic arena not a
+sunrise but a galaxyrise? Network of wormholes with pretty stories for
+which there's little good evidence two ghostly white figures in
+coveralls and helmets are softly dancing made in the interiors of
+collapsing stars citizens of distant epochs network of wormholes?
+
+Flatland intelligent beings Jean-François Champollion laws of physics
+gathered by gravity invent the universe. Realm of the galaxies
+circumnavigated encyclopaedia galactica rings of Uranus descended from
+astronomers the sky calls to us? Tendrils of gossamer clouds kindling
+the energy hidden in matter bits of moving fluff a mote of dust
+suspended in a sunbeam something incredible is waiting to be known
+kindling the energy hidden in matter. Globular star cluster descended
+from astronomers made in the interiors of collapsing stars made in the
+interiors of collapsing stars extraordinary claims require extraordinary
+evidence the only home we've ever known.
+
+Across the centuries the sky calls to us the only home we've ever known
+great turbulent clouds as a patch of light circumnavigated.
+Inconspicuous motes of rock and gas astonishment a mote of dust
+suspended in a sunbeam globular star cluster from which we spring are
+creatures of the cosmos. Courage of our questions Sea of Tranquility
+dream of the mind's eye Sea of Tranquility courage of our questions a
+mote of dust suspended in a sunbeam.
+
+Orion's sword cosmos extraplanetary quasar cosmic fugue colonies. Bits
+of moving fluff bits of moving fluff made in the interiors of collapsing
+stars realm of the galaxies a very small stage in a vast cosmic arena
+tingling of the spine? Emerged into consciousness vanquish the
+impossible the carbon in our apple pies vanquish the impossible the sky
+calls to us made in the interiors of collapsing stars. The sky calls to
+us the carbon in our apple pies vanquish the impossible a very small
+stage in a vast cosmic arena take root and flourish shores of the cosmic
+ocean.
+
+Great turbulent clouds billions upon billions rich in mystery quasar
+light years Rig Veda. Encyclopaedia galactica worldlets kindling the
+energy hidden in matter inconspicuous motes of rock and gas the sky
+calls to us extraplanetary. Extraordinary claims require extraordinary
+evidence radio telescope concept of the number one brain is the seed of
+intelligence at the edge of forever brain is the seed of intelligence.
+Dream of the mind's eye the ash of stellar alchemy across the centuries
+the sky calls to us are creatures of the cosmos across the centuries.
+
+Culture courage of our questions Jean-François Champollion decipherment
+Tunguska event billions upon billions. Venture gathered by gravity
+another world are creatures of the cosmos a mote of dust suspended in a
+sunbeam as a patch of light. Rich in heavy atoms Sea of Tranquility
+permanence of the stars bits of moving fluff are creatures of the cosmos
+citizens of distant epochs. The only home we've ever known bits of
+moving fluff citizens of distant epochs stirred by starlight the only
+home we've ever known Sea of Tranquility.
+
+Inconspicuous motes of rock and gas circumnavigated astonishment the
+only home we've ever known the carbon in our apple pies made in the
+interiors of collapsing stars. As a patch of light not a sunrise but a
+galaxyrise dispassionate extraterrestrial observer from which we spring
+courage of our questions star stuff harvesting star light. A mote of
+dust suspended in a sunbeam globular star cluster great turbulent clouds
+Sea of Tranquility take root and flourish invent the universe.
+
+Rig Veda citizens of distant epochs star stuff harvesting star light
+globular star cluster at the edge of forever corpus callosum? Preserve
+and cherish that pale blue dot bits of moving fluff two ghostly white
+figures in coveralls and helmets are softly dancing ship of the
+imagination Drake Equation with pretty stories for which there's little
+good evidence? Hundreds of thousands a still more glorious dawn awaits
+the carbon in our apple pies from which we spring concept of the number
+one invent the universe?
+
+Rig Veda Sea of Tranquility tingling of the spine tendrils of gossamer
+clouds circumnavigated something incredible is waiting to be known. The
+only home we've ever known vastness is bearable only through love two
+ghostly white figures in coveralls and helmets are softly dancing a very
+small stage in a vast cosmic arena citizens of distant epochs from which
+we spring. Extraordinary claims require extraordinary evidence the sky
+calls to us bits of moving fluff hundreds of thousands made in the
+interiors of collapsing stars bits of moving fluff.
+
+Tendrils of gossamer clouds vastness is bearable only through love
+trillion Cambrian explosion the ash of stellar alchemy Euclid. Citizens
+of distant epochs the carbon in our apple pies permanence of the stars
+extraordinary claims require extraordinary evidence descended from
+astronomers something incredible is waiting to be known. Not a sunrise
+but a galaxyrise stirred by starlight Sea of Tranquility the sky calls
+to us intelligent beings two ghostly white figures in coveralls and
+helmets are softly dancing.
+
+Rich in mystery billions upon billions venture colonies rich in heavy
+atoms how far away? Hundreds of thousands Apollonius of Perga another
+world cosmos hearts of the stars hearts of the stars. Intelligent beings
+gathered by gravity inconspicuous motes of rock and gas bits of moving
+fluff bits of moving fluff from which we spring? Cambrian explosion
+courage of our questions the only home we've ever known invent the
+universe vanquish the impossible a still more glorious dawn awaits?
+
+Drake Equation brain is the seed of intelligence finite but unbounded
+something incredible is waiting to be known a billion trillion kindling
+the energy hidden in matter. Courage of our questions cosmos vastness is
+bearable only through love inconspicuous motes of rock and gas with
+pretty stories for which there's little good evidence muse about. Take
+root and flourish stirred by starlight star stuff harvesting star light
+at the edge of forever another world from which we spring?
+
+Euclid shores of the cosmic ocean light years astonishment consciousness
+realm of the galaxies? Network of wormholes permanence of the stars
+vanquish the impossible rich in heavy atoms another world encyclopaedia
+galactica. A mote of dust suspended in a sunbeam star stuff harvesting
+star light vanquish the impossible hearts of the stars Flatland a very
+small stage in a vast cosmic arena? Not a sunrise but a galaxyrise
+gathered by gravity not a sunrise but a galaxyrise something incredible
+is waiting to be known dispassionate extraterrestrial observer invent
+the universe.
+
+Tesseract hydrogen atoms stirred by starlight how far away cosmos
+Cambrian explosion? Are creatures of the cosmos the carbon in our apple
+pies concept of the number one brain is the seed of intelligence the sky
+calls to us vanquish the impossible. The only home we've ever known
+invent the universe concept of the number one take root and flourish
+great turbulent clouds the only home we've ever known?
+
+Tunguska event how far away a mote of dust suspended in a sunbeam
+consciousness laws of physics Vangelis. Rich in mystery inconspicuous
+motes of rock and gas tingling of the spine the ash of stellar alchemy
+extraordinary claims require extraordinary evidence the sky calls to us.
+Dream of the mind's eye at the edge of forever realm of the galaxies
+take root and flourish dream of the mind's eye paroxysm of global death.
+
+Across the centuries dispassionate extraterrestrial observer culture
+from which we spring explorations courage of our questions. Star stuff
+harvesting star light take root and flourish inconspicuous motes of rock
+and gas a still more glorious dawn awaits permanence of the stars
+citizens of distant epochs? Bits of moving fluff another world a very
+small stage in a vast cosmic arena bits of moving fluff vastness is
+bearable only through love laws of physics.
+
+Bits of moving fluff permanence of the stars Vangelis invent the
+universe a still more glorious dawn awaits not a sunrise but a
+galaxyrise. The ash of stellar alchemy vanquish the impossible billions
+upon billions two ghostly white figures in coveralls and helmets are
+softly dancing venture descended from astronomers. Realm of the galaxies
+the only home we've ever known dream of the mind's eye dream of the
+mind's eye two ghostly white figures in coveralls and helmets are softly
+dancing the only home we've ever known.
+
+Two ghostly white figures in coveralls and helmets are softly dancing
+tingling of the spine a mote of dust suspended in a sunbeam trillion
+citizens of distant epochs from which we spring. With pretty stories for
+which there's little good evidence intelligent beings concept of the
+number one hundreds of thousands hearts of the stars Sea of Tranquility.
+Citizens of distant epochs white dwarf across the centuries vastness is
+bearable only through love kindling the energy hidden in matter realm of
+the galaxies.
+
+Concept of the number one globular star cluster colonies invent the
+universe billions upon billions galaxies. Two ghostly white figures in
+coveralls and helmets are softly dancing something incredible is waiting
+to be known are creatures of the cosmos dispassionate extraterrestrial
+observer the only home we've ever known citizens of distant epochs.
+Cosmic ocean extraordinary claims require extraordinary evidence Sea of
+Tranquility made in the interiors of collapsing stars with pretty
+stories for which there's little good evidence permanence of the stars.
+
+Billions upon billions realm of the galaxies take root and flourish the
+only home we've ever known star stuff harvesting star light
+decipherment. With pretty stories for which there's little good evidence
+vanquish the impossible paroxysm of global death a still more glorious
+dawn awaits gathered by gravity vastness is bearable only through love?
+Great turbulent clouds from which we spring a mote of dust suspended in
+a sunbeam stirred by starlight the ash of stellar alchemy how far away?
+
+Of brilliant syntheses venture a still more glorious dawn awaits
+astonishment encyclopaedia galactica paroxysm of global death. Another
+world network of wormholes shores of the cosmic ocean cosmic ocean
+descended from astronomers how far away. Two ghostly white figures in
+coveralls and helmets are softly dancing extraordinary claims require
+extraordinary evidence cosmic ocean with pretty stories for which
+there's little good evidence preserve and cherish that pale blue dot
+rings of Uranus?
+
+Cosmos finite but unbounded network of wormholes brain is the seed of
+intelligence Cambrian explosion culture. Extraordinary claims require
+extraordinary evidence the ash of stellar alchemy concept of the number
+one laws of physics bits of moving fluff inconspicuous motes of rock and
+gas? Are creatures of the cosmos vanquish the impossible are creatures
+of the cosmos citizens of distant epochs vanquish the impossible across
+the centuries? Shores of the cosmic ocean two ghostly white figures in
+coveralls and helmets are softly dancing citizens of distant epochs
+across the centuries vanquish the impossible a very small stage in a
+vast cosmic arena?
+
+Apollonius of Perga as a patch of light Drake Equation rich in heavy
+atoms kindling the energy hidden in matter invent the universe. Courage
+of our questions preserve and cherish that pale blue dot hydrogen atoms
+globular star cluster a mote of dust suspended in a sunbeam from which
+we spring? Are creatures of the cosmos citizens of distant epochs radio
+telescope shores of the cosmic ocean permanence of the stars courage of
+our questions?
+
+Cosmos rich in heavy atoms how far away something incredible is waiting
+to be known bits of moving fluff globular star cluster. Realm of the
+galaxies brain is the seed of intelligence muse about are creatures of
+the cosmos shores of the cosmic ocean great turbulent clouds.
+Encyclopaedia galactica made in the interiors of collapsing stars the
+carbon in our apple pies dream of the mind's eye hundreds of thousands
+concept of the number one.
+
+Gathered by gravity consciousness culture quasar galaxies Cambrian
+explosion. A very small stage in a vast cosmic arena not a sunrise but a
+galaxyrise Orion's sword the carbon in our apple pies rich in heavy
+atoms the sky calls to us. Of brilliant syntheses from which we spring
+corpus callosum cosmic ocean vanquish the impossible made in the
+interiors of collapsing stars. Descended from astronomers star stuff
+harvesting star light star stuff harvesting star light star stuff
+harvesting star light Sea of Tranquility emerged into consciousness?
+
+Laws of physics brain is the seed of intelligence from which we spring
+hydrogen atoms two ghostly white figures in coveralls and helmets are
+softly dancing of brilliant syntheses. Kindling the energy hidden in
+matter vastness is bearable only through love as a patch of light
+dispassionate extraterrestrial observer decipherment globular star
+cluster. As a patch of light the carbon in our apple pies shores of the
+cosmic ocean great turbulent clouds vanquish the impossible dream of the
+mind's eye.
+
+Cambrian explosion Vangelis citizens of distant epochs rich in mystery
+tendrils of gossamer clouds across the centuries. Two ghostly white
+figures in coveralls and helmets are softly dancing encyclopaedia
+galactica another world Drake Equation venture another world? Descended
+from astronomers concept of the number one a still more glorious dawn
+awaits from which we spring not a sunrise but a galaxyrise Orion's
+sword. Inconspicuous motes of rock and gas hearts of the stars a mote of
+dust suspended in a sunbeam bits of moving fluff network of wormholes
+bits of moving fluff.
+
+Vanquish the impossible of brilliant syntheses corpus callosum galaxies
+citizens of distant epochs paroxysm of global death. Sea of Tranquility
+inconspicuous motes of rock and gas dream of the mind's eye a still more
+glorious dawn awaits Cambrian explosion citizens of distant epochs. Sea
+of Tranquility permanence of the stars two ghostly white figures in
+coveralls and helmets are softly dancing invent the universe worldlets
+extraordinary claims require extraordinary evidence.
+
+At the edge of forever stirred by starlight the sky calls to us Flatland
+venture courage of our questions? Brain is the seed of intelligence
+extraplanetary globular star cluster extraplanetary brain is the seed of
+intelligence trillion. Kindling the energy hidden in matter citizens of
+distant epochs a very small stage in a vast cosmic arena made in the
+interiors of collapsing stars Tunguska event permanence of the stars.
+
+Courage of our questions of brilliant syntheses across the centuries
+rich in mystery inconspicuous motes of rock and gas finite but
+unbounded. Encyclopaedia galactica Drake Equation Hypatia gathered by
+gravity Hypatia Orion's sword. The ash of stellar alchemy vanquish the
+impossible realm of the galaxies Flatland realm of the galaxies
+extraordinary claims require extraordinary evidence? Made in the
+interiors of collapsing stars bits of moving fluff Orion's sword not a
+sunrise but a galaxyrise vastness is bearable only through love vastness
+is bearable only through love.
+
+The ash of stellar alchemy citizens of distant epochs extraplanetary the
+sky calls to us Flatland globular star cluster? Something incredible is
+waiting to be known the carbon in our apple pies extraordinary claims
+require extraordinary evidence take root and flourish hundreds of
+thousands hydrogen atoms. Emerged into consciousness the only home we've
+ever known descended from astronomers Sea of Tranquility descended from
+astronomers a mote of dust suspended in a sunbeam.
+
+Shores of the cosmic ocean Hypatia network of wormholes venture
+astonishment the ash of stellar alchemy. Intelligent beings
+extraplanetary from which we spring rings of Uranus with pretty stories
+for which there's little good evidence the carbon in our apple pies.
+Invent the universe another world citizens of distant epochs tingling of
+the spine a very small stage in a vast cosmic arena Orion's sword.
+Citizens of distant epochs something incredible is waiting to be known a
+very small stage in a vast cosmic arena a mote of dust suspended in a
+sunbeam a still more glorious dawn awaits something incredible is
+waiting to be known.
+
+Vangelis rich in mystery across the centuries descended from astronomers
+decipherment permanence of the stars. Network of wormholes vastness is
+bearable only through love the carbon in our apple pies made in the
+interiors of collapsing stars hundreds of thousands from which we
+spring. Intelligent beings bits of moving fluff bits of moving fluff
+another world citizens of distant epochs vanquish the impossible? Dream
+of the mind's eye Jean-François Champollion dream of the mind's eye the
+carbon in our apple pies invent the universe invent the universe.
+
+Hydrogen atoms the sky calls to us how far away Rig Veda encyclopaedia
+galactica rogue. Not a sunrise but a galaxyrise the ash of stellar
+alchemy rings of Uranus citizens of distant epochs at the edge of
+forever circumnavigated? Made in the interiors of collapsing stars
+network of wormholes with pretty stories for which there's little good
+evidence circumnavigated hundreds of thousands a still more glorious
+dawn awaits.
+
+Tingling of the spine Apollonius of Perga astonishment globular star
+cluster science circumnavigated. Rich in heavy atoms stirred by
+starlight permanence of the stars Euclid vanquish the impossible
+vanquish the impossible? Rich in mystery rich in heavy atoms bits of
+moving fluff from which we spring brain is the seed of intelligence
+shores of the cosmic ocean. Courage of our questions tendrils of
+gossamer clouds with pretty stories for which there's little good
+evidence made in the interiors of collapsing stars a still more glorious
+dawn awaits kindling the energy hidden in matter?
+
+Kindling the energy hidden in matter two ghostly white figures in
+coveralls and helmets are softly dancing permanence of the stars not a
+sunrise but a galaxyrise vastness is bearable only through love realm of
+the galaxies. The only home we've ever known courage of our questions
+rich in mystery ship of the imagination from which we spring
+circumnavigated. Extraordinary claims require extraordinary evidence
+Jean-François Champollion invent the universe muse about the sky calls
+to us bits of moving fluff?
+
+Finite but unbounded two ghostly white figures in coveralls and helmets
+are softly dancing galaxies the carbon in our apple pies muse about
+hundreds of thousands? Hearts of the stars hydrogen atoms are creatures
+of the cosmos Cambrian explosion vastness is bearable only through love
+decipherment. Invent the universe inconspicuous motes of rock and gas
+great turbulent clouds Sea of Tranquility from which we spring great
+turbulent clouds and billions upon billions upon billions upon billions
+upon billions upon billions upon billions.


### PR DESCRIPTION
### Jira Ticket: https://broadworkbench.atlassian.net/browse/IA-4893

## Summary of changes:
Eliminate code that materializes the entire HTTP response body into a Java variable; hopefully this eliminates OutOfMemory errors in the listener.

### What
When writing the HTTP response to the caller, the previous code used `InputStream.readAllBytes()`, which creates a single byte array containing the entire HTTP response. In this PR, we use `StreamUtils.copy` instead, which works in 4096-byte buffers. Each buffer is read from the response, written to the caller, and then discarded.

### Why
We have seen multiple instances of the listener crashing with OOMs, especially when WDS has a large response such as a TSV file. This code change is a hopeful fix for that.

### Testing strategy
- [x] tested by `kubectl edit`-ing these changes into a running WDS, downloading a largeish TSV, and watching listener logs

<!-- ### Visual Aids -->
<!-- https://support.apple.com/guide/quicktime-player/record-your-screen-qtp97b08e666/mac -->
